### PR TITLE
fix: Update publicEmail state after form submission

### DIFF
--- a/Controllers/Website/Account/Account.php
+++ b/Controllers/Website/Account/Account.php
@@ -185,6 +185,7 @@ class Account extends WebpageController
 
         self::$data['account_name'] = $displayName;
 	    self::$data['account_email'] = $email;
+	    self::$data['account_publicEmail'] = $publicEmail;
 	    self::$data['account_discord'] = $discord;
 	    self::$data['account_youtube'] = $youtube;
 	    self::$data['account_twitter'] = $twitter;


### PR DESCRIPTION
The Hide e-mail checkbox was not updating after form submission because the account_publicEmail data was not being set with the new value. This caused the checkbox to display the old state from the database instead of reflecting the user's submitted choice.

Fixes #153