### PR TITLE
Switch NPC images from PNG to WebP

### DIFF
--- a/Controllers/Api/Other/NpcSearch.php
+++ b/Controllers/Api/Other/NpcSearch.php
@@ -68,7 +68,7 @@ class NpcSearch extends ApiController
         if ($noPicture) {
             $storage = Storage::get();
             $npcs = array_values(array_filter($npcs, function (array $npc) use ($storage): bool {
-                return !$storage->exists('npcs/' . $npc['npc_id'] . '.png');
+                return !$storage->exists('npcs/' . $npc['npc_id'] . '.webp');
             }));
         }
 

--- a/Models/Website/Npc.php
+++ b/Models/Website/Npc.php
@@ -363,7 +363,7 @@ class Npc implements JsonSerializable
         unset($replacementId);
 
         //Copy profile picture
-        Storage::get()->copy('npcs/'.$this->id.'.png', 'npcs/'.$replacementNpc->getId().'.png');
+        Storage::get()->copy('npcs/'.$this->id.'.webp', 'npcs/'.$replacementNpc->getId().'.webp');
 
         //Unlink this NPC from all quests and link the new one
         $inString = trim(str_repeat('?,', count($questIds)), ',');

--- a/Views/npc.phtml
+++ b/Views/npc.phtml
@@ -7,7 +7,7 @@
 <section class="npc-hero npc-animate-fade-in">
     <div class="npc-hero-content">
         <h1 class="npc-hero-title"><?= ${basename(__FILE__, '.phtml') . '_npc'}->getName() ?><?php if (${basename(__FILE__, '.phtml') . '_npc'}->isArchived()) : ?> <span class="outdated-tag">outdated</span><?php endif ?></h1>
-        <img class="npc-avatar" src="<?= \VoicesOfWynn\storageUrl('npcs/' . ${basename(__FILE__, '.phtml') . '_npc'}->getId() . '.png') ?>" onerror="this.onerror=null; this.src='<?= \VoicesOfWynn\storageUrl('npcs/default.png') ?>'" alt="NPC picture" />
+        <img class="npc-avatar" src="<?= \VoicesOfWynn\storageUrl('npcs/' . ${basename(__FILE__, '.phtml') . '_npc'}->getId() . '.webp') ?>" onerror="this.onerror=null; this.src='<?= \VoicesOfWynn\storageUrl('npcs/default.webp') ?>'" alt="NPC picture" />
     </div>
 </section>
 

--- a/Views/partials/npc-card.phtml
+++ b/Views/partials/npc-card.phtml
@@ -22,8 +22,8 @@ $cardShowVoiceActor        = $cardShowVoiceActor        ?? true;
             <a href="contents/npc/<?= $cardNpc->getId() ?>" class="cast-npc-link cast-npc-link--pic">
                 <img
                     class="cast-npc-pic"
-                    src="<?= \VoicesOfWynn\storageUrl('npcs/' . $cardNpc->getId() . '.png') ?>"
-                    onerror="this.onerror=null; this.src='<?= \VoicesOfWynn\storageUrl('npcs/default.png') ?>'"
+                    src="<?= \VoicesOfWynn\storageUrl('npcs/' . $cardNpc->getId() . '.webp') ?>"
+                    onerror="this.onerror=null; this.src='<?= \VoicesOfWynn\storageUrl('npcs/default.webp') ?>'"
                     alt="<?= htmlspecialchars($cardNpc->getName()) ?>"
                     loading="lazy"
                 />


### PR DESCRIPTION
## Summary
- All NPC pictures in blob storage have been converted to WebP format
- Updated image src and onerror fallback in the NPC card partial and NPC detail page
- Updated the `no_picture` API filter to check for `.webp` instead of `.png`
- Updated the NPC copy operation to copy `.webp` files



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * NPC images now served in WebP format instead of PNG
  * Search filtering updated to check WebP image availability
  * NPC archival process updated for WebP assets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->