### PR TITLE
feat: make staff credits view look good and add admin page to manage these

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@ PHP website for the Voices of Wynn project — a Wynncraft mod that adds voiced 
 - Keep logic out of views. Data shaping and conditionals belong in controllers or models; views should only render pre-computed variables.
 - Prefer model methods over `ContentManager`. `ContentManager` is a legacy convenience class for a narrow set of info-getting procedures. Logic that naturally belongs to a database model (`Quest`, `Npc`, etc.) should live there as a method/getter, not in `ContentManager`. Do not expand it for new features.
 - Avoid static database fetchers on models; prefer constructing a model with identifying data and loading the rest through an instance method.
+- One column-to-property mapping per model: the constructor's `$data` switch (or a `setData()` it delegates to). `loadFromX()` methods feed their fetched row into it instead of re-mapping.
 - XSS escaping is handled globally by `WebpageController`. Do not call `htmlspecialchars()` manually in views.
 - Check PDO query success by testing whether the result is not `false` (truthy check).
 - Avoid unnecessary type casts — don't cast values that are already the correct type.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ PHP website for the Voices of Wynn project — a Wynncraft mod that adds voiced 
 - One column-to-property mapping per model: the constructor's `$data` switch (or a `setData()` it delegates to). `loadFromX()` methods feed their fetched row into it instead of re-mapping.
 - XSS escaping is handled globally by `WebpageController`. Do not call `htmlspecialchars()` manually in views.
 - Check PDO query success by testing whether the result is not `false` (truthy check).
-- Avoid unnecessary type casts — don't cast values that are already the correct type.
+- Don't cast numeric strings to int unless strictly necessary — PHP's implicit conversion handles it.
 - Validate IDs against the database, not with `is_numeric()` / `> 0` checks alone. Those pass values like `42069` that don't correspond to real records. Either validate against the actual list of IDs from the DB, or skip numeric validation and let the DB query return no results naturally.
 - Validate string inputs against the DB column length (check the schema). Use `mb_strlen()` for multi-byte safety.
 - Shared logic between models (`Quest`, `Npc`, etc.) belongs in `ContentModel`, the abstract base class both extend.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Voices of Wynn Website
+
+PHP website for the Voices of Wynn project — a Wynncraft mod that adds voiced NPC dialogue. Custom MVC framework: routes defined in `routes.ini`, controllers in `Controllers/`, models in `Models/`, views as `.phtml` files in `Views/`.
+
+## Guidelines
+
+- Keep logic out of views. Data shaping and conditionals belong in controllers or models; views should only render pre-computed variables.
+- Prefer model methods over `ContentManager`. `ContentManager` is a legacy convenience class for a narrow set of info-getting procedures. Logic that naturally belongs to a database model (`Quest`, `Npc`, etc.) should live there as a method/getter, not in `ContentManager`. Do not expand it for new features.
+- Avoid static database fetchers on models; prefer constructing a model with identifying data and loading the rest through an instance method.
+- XSS escaping is handled globally by `WebpageController`. Do not call `htmlspecialchars()` manually in views.
+- Check PDO query success by testing whether the result is not `false` (truthy check).
+- Avoid unnecessary type casts — don't cast values that are already the correct type.
+- Validate IDs against the database, not with `is_numeric()` / `> 0` checks alone. Those pass values like `42069` that don't correspond to real records. Either validate against the actual list of IDs from the DB, or skip numeric validation and let the DB query return no results naturally.
+- Validate string inputs against the DB column length (check the schema). Use `mb_strlen()` for multi-byte safety.
+- Shared logic between models (`Quest`, `Npc`, etc.) belongs in `ContentModel`, the abstract base class both extend.

--- a/Controllers/Website/Administration/Administration.php
+++ b/Controllers/Website/Administration/Administration.php
@@ -48,6 +48,9 @@ class Administration extends WebpageController
             case 'new-release':
                 $nextController = new NewRelease();
                 break;
+            case 'scripts':
+                $nextController = new Scripts();
+                break;
 	        default:
 	        	$nextController = new Accounts();
         }

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -82,7 +82,7 @@ class Scripts extends WebpageController
                 break;
 
             case 'set-editor':
-                $questId = (int)($_POST['quest_id'] ?? 0);
+                $questId = $_POST['quest_id'] ?? 0;
                 $npcId = (int)($_POST['npc_id'] ?? 0);
                 $editorId = !empty($_POST['editor_id']) ? (int)$_POST['editor_id'] : null;
                 if ($cm->getQuestDegeneratedName($questId) === null) {

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -29,14 +29,8 @@ class Scripts extends WebpageController
         $total   = $cm->countQuests();
         $quests  = $cm->getQuestsWithCredits($page, $perPage);
 
-        $storage = Storage::get();
-        foreach ($quests as &$quest) {
-            $quest['has_script'] = $storage->exists('scripts/' . $quest['degenerated_name'] . '.txt');
-            $quest['script_url'] = $storage->getUrl('scripts/' . $quest['degenerated_name'] . '.txt');
-        }
-        unset($quest);
-
         self::$data['scripts_quests']       = $quests;
+        self::$data['scripts_storage']      = Storage::get();
         self::$data['scripts_users']        = $cm->getUsersForDropdown();
         self::$data['scripts_current_page'] = $page;
         self::$data['scripts_total_pages']  = (int)ceil($total / $perPage);

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace VoicesOfWynn\Controllers\Website\Administration;
+
+use VoicesOfWynn\Controllers\Website\WebpageController;
+use VoicesOfWynn\Models\Storage\Storage;
+use VoicesOfWynn\Models\Website\ContentManager;
+
+class Scripts extends WebpageController
+{
+    public function process(array $args): int
+    {
+        switch ($_SERVER['REQUEST_METHOD']) {
+            case 'GET':
+                return $this->get();
+            case 'POST':
+                return $this->post();
+            default:
+                return 405;
+        }
+    }
+
+    private function get(): int
+    {
+        $page    = max(1, (int)($_GET['page'] ?? 1));
+        $perPage = 25;
+        $cm      = new ContentManager();
+        $total   = $cm->countQuests();
+        $quests  = $cm->getQuestsWithCredits($page, $perPage);
+
+        $storage = Storage::get();
+        foreach ($quests as &$quest) {
+            $quest['has_script'] = $storage->exists('scripts/' . $quest['degenerated_name'] . '.txt');
+            $quest['script_url'] = $storage->getUrl('scripts/' . $quest['degenerated_name'] . '.txt');
+        }
+        unset($quest);
+
+        self::$data['scripts_quests']       = $quests;
+        self::$data['scripts_users']        = $cm->getUsersForDropdown();
+        self::$data['scripts_current_page'] = $page;
+        self::$data['scripts_total_pages']  = (int)ceil($total / $perPage);
+        self::$data['scripts_message']      = self::$data['scripts_message'] ?? null;
+        self::$data['scripts_error']        = self::$data['scripts_error'] ?? null;
+        self::$views[] = 'scripts';
+        return 200;
+    }
+
+    private function post(): int
+    {
+        $action = $_POST['action'] ?? '';
+        $cm = new ContentManager();
+
+        switch ($action) {
+            case 'set-writer':
+                $questId = (int)($_POST['quest_id'] ?? 0);
+                $writerId = !empty($_POST['writer_id']) ? (int)$_POST['writer_id'] : null;
+                if ($questId <= 0) {
+                    self::$data['scripts_error'] = 'Invalid quest ID.';
+                    break;
+                }
+                $cm->setQuestWriter($questId, $writerId);
+                self::$data['scripts_message'] = 'Writer updated.';
+                break;
+
+            case 'upload-script':
+                $questId = (int)($_POST['quest_id'] ?? 0);
+                $degeneratedName = $_POST['degenerated_name'] ?? '';
+                if ($questId <= 0 || empty($degeneratedName)) {
+                    self::$data['scripts_error'] = 'Invalid quest.';
+                    break;
+                }
+                if (empty($_FILES['script_file']['tmp_name']) || $_FILES['script_file']['error'] !== UPLOAD_ERR_OK) {
+                    self::$data['scripts_error'] = 'No file uploaded or upload error.';
+                    break;
+                }
+                Storage::get()->upload($_FILES['script_file']['tmp_name'], 'scripts/' . $degeneratedName . '.txt', 'text/plain');
+                self::$data['scripts_message'] = 'Script file uploaded for "' . htmlspecialchars($degeneratedName) . '".';
+                break;
+
+            case 'set-editor':
+                $questId = (int)($_POST['quest_id'] ?? 0);
+                $npcId = (int)($_POST['npc_id'] ?? 0);
+                $editorId = !empty($_POST['editor_id']) ? (int)$_POST['editor_id'] : null;
+                if ($questId <= 0 || $npcId <= 0) {
+                    self::$data['scripts_error'] = 'Invalid quest or NPC ID.';
+                    break;
+                }
+                $cm->setNpcEditor($questId, $npcId, $editorId);
+                self::$data['scripts_message'] = 'Editor updated.';
+                break;
+
+            case 'save-quest':
+                $questId = (int)($_POST['quest_id'] ?? 0);
+                $degeneratedName = $_POST['degenerated_name'] ?? '';
+                if ($questId <= 0) {
+                    self::$data['scripts_error'] = 'Invalid quest ID.';
+                    break;
+                }
+                $writerId = !empty($_POST['writer_id']) ? (int)$_POST['writer_id'] : null;
+                $cm->setQuestWriter($questId, $writerId);
+                if (!empty($_FILES['script_file']['tmp_name']) && $_FILES['script_file']['error'] === UPLOAD_ERR_OK) {
+                    Storage::get()->upload($_FILES['script_file']['tmp_name'], 'scripts/' . $degeneratedName . '.txt', 'text/plain');
+                }
+                foreach (($_POST['npc_editors'] ?? []) as $npcId => $editorId) {
+                    $cm->setNpcEditor($questId, (int)$npcId, !empty($editorId) ? (int)$editorId : null);
+                }
+                self::$data['scripts_message'] = 'Quest saved.';
+                break;
+
+            default:
+                return 400;
+        }
+
+        return $this->get();
+    }
+}

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -54,8 +54,8 @@ class Scripts extends WebpageController
             case 'set-writer':
                 $questId = (int)($_POST['quest_id'] ?? 0);
                 $writerId = !empty($_POST['writer_id']) ? (int)$_POST['writer_id'] : null;
-                if ($questId <= 0) {
-                    self::$data['scripts_error'] = 'Invalid quest ID.';
+                if ($cm->getQuestDegeneratedName($questId) === null) {
+                    self::$data['scripts_error'] = 'Quest not found.';
                     break;
                 }
                 $cm->setQuestWriter($questId, $writerId);
@@ -85,8 +85,12 @@ class Scripts extends WebpageController
                 $questId = (int)($_POST['quest_id'] ?? 0);
                 $npcId = (int)($_POST['npc_id'] ?? 0);
                 $editorId = !empty($_POST['editor_id']) ? (int)$_POST['editor_id'] : null;
-                if ($questId <= 0 || $npcId <= 0) {
-                    self::$data['scripts_error'] = 'Invalid quest or NPC ID.';
+                if ($cm->getQuestDegeneratedName($questId) === null) {
+                    self::$data['scripts_error'] = 'Quest not found.';
+                    break;
+                }
+                if ($npcId <= 0) {
+                    self::$data['scripts_error'] = 'Invalid NPC ID.';
                     break;
                 }
                 $cm->setNpcEditor($questId, $npcId, $editorId);

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -64,9 +64,13 @@ class Scripts extends WebpageController
 
             case 'upload-script':
                 $questId = (int)($_POST['quest_id'] ?? 0);
-                $degeneratedName = $_POST['degenerated_name'] ?? '';
-                if ($questId <= 0 || empty($degeneratedName)) {
+                if ($questId <= 0) {
                     self::$data['scripts_error'] = 'Invalid quest.';
+                    break;
+                }
+                $degeneratedName = $cm->getQuestDegeneratedName($questId);
+                if ($degeneratedName === null) {
+                    self::$data['scripts_error'] = 'Quest not found.';
                     break;
                 }
                 if (empty($_FILES['script_file']['tmp_name']) || $_FILES['script_file']['error'] !== UPLOAD_ERR_OK) {
@@ -91,9 +95,13 @@ class Scripts extends WebpageController
 
             case 'save-quest':
                 $questId = (int)($_POST['quest_id'] ?? 0);
-                $degeneratedName = $_POST['degenerated_name'] ?? '';
                 if ($questId <= 0) {
                     self::$data['scripts_error'] = 'Invalid quest ID.';
+                    break;
+                }
+                $degeneratedName = $cm->getQuestDegeneratedName($questId);
+                if ($degeneratedName === null) {
+                    self::$data['scripts_error'] = 'Quest not found.';
                     break;
                 }
                 $writerId = !empty($_POST['writer_id']) ? (int)$_POST['writer_id'] : null;

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -5,6 +5,7 @@ namespace VoicesOfWynn\Controllers\Website\Administration;
 use VoicesOfWynn\Controllers\Website\WebpageController;
 use VoicesOfWynn\Models\Storage\Storage;
 use VoicesOfWynn\Models\Website\ContentManager;
+use VoicesOfWynn\Models\Website\Quest;
 
 class Scripts extends WebpageController
 {
@@ -54,11 +55,12 @@ class Scripts extends WebpageController
             case 'set-writer':
                 $questId = (int)($_POST['quest_id'] ?? 0);
                 $writerId = !empty($_POST['writer_id']) ? (int)$_POST['writer_id'] : null;
-                if ($cm->getQuestDegeneratedName($questId) === null) {
+                $quest = Quest::findById($questId);
+                if ($quest === null) {
                     self::$data['scripts_error'] = 'Quest not found.';
                     break;
                 }
-                $cm->setQuestWriter($questId, $writerId);
+                $quest->setWriter($writerId);
                 self::$data['scripts_message'] = 'Writer updated.';
                 break;
 
@@ -68,8 +70,8 @@ class Scripts extends WebpageController
                     self::$data['scripts_error'] = 'Invalid quest.';
                     break;
                 }
-                $degeneratedName = $cm->getQuestDegeneratedName($questId);
-                if ($degeneratedName === null) {
+                $quest = Quest::findById($questId);
+                if ($quest === null) {
                     self::$data['scripts_error'] = 'Quest not found.';
                     break;
                 }
@@ -77,15 +79,17 @@ class Scripts extends WebpageController
                     self::$data['scripts_error'] = 'No file uploaded or upload error.';
                     break;
                 }
+                $degeneratedName = $quest->getDegeneratedName();
                 Storage::get()->upload($_FILES['script_file']['tmp_name'], 'scripts/' . $degeneratedName . '.txt', 'text/plain');
                 self::$data['scripts_message'] = 'Script file uploaded for "' . htmlspecialchars($degeneratedName) . '".';
                 break;
 
             case 'set-editor':
-                $questId = $_POST['quest_id'] ?? 0;
+                $questId = (int)($_POST['quest_id'] ?? 0);
                 $npcId = (int)($_POST['npc_id'] ?? 0);
                 $editorId = !empty($_POST['editor_id']) ? (int)$_POST['editor_id'] : null;
-                if ($cm->getQuestDegeneratedName($questId) === null) {
+                $quest = Quest::findById($questId);
+                if ($quest === null) {
                     self::$data['scripts_error'] = 'Quest not found.';
                     break;
                 }
@@ -93,7 +97,7 @@ class Scripts extends WebpageController
                     self::$data['scripts_error'] = 'Invalid NPC ID.';
                     break;
                 }
-                $cm->setNpcEditor($questId, $npcId, $editorId);
+                $quest->setNpcEditor($npcId, $editorId);
                 self::$data['scripts_message'] = 'Editor updated.';
                 break;
 
@@ -103,18 +107,19 @@ class Scripts extends WebpageController
                     self::$data['scripts_error'] = 'Invalid quest ID.';
                     break;
                 }
-                $degeneratedName = $cm->getQuestDegeneratedName($questId);
-                if ($degeneratedName === null) {
+                $quest = Quest::findById($questId);
+                if ($quest === null) {
                     self::$data['scripts_error'] = 'Quest not found.';
                     break;
                 }
                 $writerId = !empty($_POST['writer_id']) ? (int)$_POST['writer_id'] : null;
-                $cm->setQuestWriter($questId, $writerId);
+                $quest->setWriter($writerId);
+                $degeneratedName = $quest->getDegeneratedName();
                 if (!empty($_FILES['script_file']['tmp_name']) && $_FILES['script_file']['error'] === UPLOAD_ERR_OK) {
                     Storage::get()->upload($_FILES['script_file']['tmp_name'], 'scripts/' . $degeneratedName . '.txt', 'text/plain');
                 }
                 foreach (($_POST['npc_editors'] ?? []) as $npcId => $editorId) {
-                    $cm->setNpcEditor($questId, (int)$npcId, !empty($editorId) ? (int)$editorId : null);
+                    $quest->setNpcEditor((int)$npcId, !empty($editorId) ? (int)$editorId : null);
                 }
                 self::$data['scripts_message'] = 'Quest saved.';
                 break;

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -30,7 +30,6 @@ class Scripts extends WebpageController
         $quests  = $cm->getQuestsWithCredits($page, $perPage);
 
         self::$data['scripts_quests']       = $quests;
-        self::$data['scripts_storage']      = Storage::get();
         self::$data['scripts_users']        = $cm->getUsersForDropdown();
         self::$data['scripts_current_page'] = $page;
         self::$data['scripts_total_pages']  = (int)ceil($total / $perPage);

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -28,13 +28,15 @@ class Scripts extends WebpageController
         $cm      = new ContentManager();
         $total   = $cm->countQuests();
         $quests  = $cm->getQuestsWithCredits($page, $perPage);
+        $flash   = $_SESSION['scripts_flash'] ?? [];
+        unset($_SESSION['scripts_flash']);
 
         self::$data['scripts_quests']       = $quests;
         self::$data['scripts_users']        = $cm->getUsersForDropdown();
         self::$data['scripts_current_page'] = $page;
         self::$data['scripts_total_pages']  = (int)ceil($total / $perPage);
-        self::$data['scripts_message']      = self::$data['scripts_message'] ?? null;
-        self::$data['scripts_error']        = self::$data['scripts_error'] ?? null;
+        self::$data['scripts_message']      = $flash['message'] ?? null;
+        self::$data['scripts_error']        = $flash['error'] ?? null;
         self::$views[] = 'scripts';
         return 200;
     }
@@ -42,50 +44,43 @@ class Scripts extends WebpageController
     private function post(): int
     {
         $action = $_POST['action'] ?? '';
-        $cm = new ContentManager();
+        $message = null;
+        $error = null;
 
         switch ($action) {
             case 'set-writer':
                 $questId = (int)($_POST['quest_id'] ?? 0);
                 $writerId = !empty($_POST['writer_id']) ? (int)$_POST['writer_id'] : null;
-                $quest = Quest::findById($questId);
-                if ($quest === null) {
-                    self::$data['scripts_error'] = 'Quest not found.';
+                $quest = new Quest(['id' => $questId]);
+                if (!$quest->loadFromId()) {
+                    $error = 'Quest not found.';
                     break;
                 }
                 $quest->setWriter($writerId);
-                self::$data['scripts_message'] = 'Writer updated.';
+                $message = 'Writer updated.';
                 break;
 
             case 'upload-script':
                 $questId = (int)($_POST['quest_id'] ?? 0);
-                if ($questId <= 0) {
-                    self::$data['scripts_error'] = 'Invalid quest.';
-                    break;
-                }
-                $quest = Quest::findById($questId);
-                if ($quest === null) {
-                    self::$data['scripts_error'] = 'Quest not found.';
+                $quest = new Quest(['id' => $questId]);
+                if (!$quest->loadFromId()) {
+                    $error = 'Quest not found.';
                     break;
                 }
                 if (empty($_FILES['script_file']['tmp_name']) || $_FILES['script_file']['error'] !== UPLOAD_ERR_OK) {
-                    self::$data['scripts_error'] = 'No file uploaded or upload error.';
+                    $error = 'No file uploaded or upload error.';
                     break;
                 }
                 $degeneratedName = $quest->getDegeneratedName();
                 Storage::get()->upload($_FILES['script_file']['tmp_name'], 'scripts/' . $degeneratedName . '.txt', 'text/plain');
-                self::$data['scripts_message'] = 'Script file uploaded for "' . $degeneratedName . '".';
+                $message = 'Script file uploaded for "' . $degeneratedName . '".';
                 break;
 
             case 'save-quest':
                 $questId = (int)($_POST['quest_id'] ?? 0);
-                if ($questId <= 0) {
-                    self::$data['scripts_error'] = 'Invalid quest ID.';
-                    break;
-                }
-                $quest = Quest::findById($questId);
-                if ($quest === null) {
-                    self::$data['scripts_error'] = 'Quest not found.';
+                $quest = new Quest(['id' => $questId]);
+                if (!$quest->loadFromId()) {
+                    $error = 'Quest not found.';
                     break;
                 }
                 $writerId = !empty($_POST['writer_id']) ? (int)$_POST['writer_id'] : null;
@@ -97,17 +92,25 @@ class Scripts extends WebpageController
                 foreach (($_POST['npc_editors'] ?? []) as $npcId => $editorId) {
                     $editorSaved = $quest->setNpcEditor((int)$npcId, !empty($editorId) ? (int)$editorId : null);
                     if (!$editorSaved) {
-                        self::$data['scripts_error'] = 'NPC not found for this quest.';
+                        $error = 'NPC not found for this quest.';
                         break 2;
                     }
                 }
-                self::$data['scripts_message'] = 'Quest saved.';
+                $message = 'Quest saved.';
                 break;
 
             default:
                 return 400;
         }
 
-        return $this->get();
+        $_SESSION['scripts_flash'] = [
+            'message' => $message,
+            'error' => $error,
+        ];
+
+        $page = max(1, (int)($_GET['page'] ?? 1));
+        header('Location: /administration/scripts?page=' . $page);
+        header('HTTP/1.1 303 See Other');
+        return 303;
     }
 }

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -74,7 +74,7 @@ class Scripts extends WebpageController
                 }
                 $degeneratedName = $quest->getDegeneratedName();
                 Storage::get()->upload($_FILES['script_file']['tmp_name'], 'scripts/' . $degeneratedName . '.txt', 'text/plain');
-                self::$data['scripts_message'] = 'Script file uploaded for "' . htmlspecialchars($degeneratedName) . '".';
+                self::$data['scripts_message'] = 'Script file uploaded for "' . $degeneratedName . '".';
                 break;
 
             case 'set-editor':

--- a/Controllers/Website/Administration/Scripts.php
+++ b/Controllers/Website/Administration/Scripts.php
@@ -77,23 +77,6 @@ class Scripts extends WebpageController
                 self::$data['scripts_message'] = 'Script file uploaded for "' . $degeneratedName . '".';
                 break;
 
-            case 'set-editor':
-                $questId = (int)($_POST['quest_id'] ?? 0);
-                $npcId = (int)($_POST['npc_id'] ?? 0);
-                $editorId = !empty($_POST['editor_id']) ? (int)$_POST['editor_id'] : null;
-                $quest = Quest::findById($questId);
-                if ($quest === null) {
-                    self::$data['scripts_error'] = 'Quest not found.';
-                    break;
-                }
-                if ($npcId <= 0) {
-                    self::$data['scripts_error'] = 'Invalid NPC ID.';
-                    break;
-                }
-                $quest->setNpcEditor($npcId, $editorId);
-                self::$data['scripts_message'] = 'Editor updated.';
-                break;
-
             case 'save-quest':
                 $questId = (int)($_POST['quest_id'] ?? 0);
                 if ($questId <= 0) {
@@ -112,7 +95,11 @@ class Scripts extends WebpageController
                     Storage::get()->upload($_FILES['script_file']['tmp_name'], 'scripts/' . $degeneratedName . '.txt', 'text/plain');
                 }
                 foreach (($_POST['npc_editors'] ?? []) as $npcId => $editorId) {
-                    $quest->setNpcEditor((int)$npcId, !empty($editorId) ? (int)$editorId : null);
+                    $editorSaved = $quest->setNpcEditor((int)$npcId, !empty($editorId) ? (int)$editorId : null);
+                    if (!$editorSaved) {
+                        self::$data['scripts_error'] = 'NPC not found for this quest.';
+                        break 2;
+                    }
                 }
                 self::$data['scripts_message'] = 'Quest saved.';
                 break;

--- a/Controllers/Website/Cast.php
+++ b/Controllers/Website/Cast.php
@@ -2,6 +2,7 @@
 
 namespace VoicesOfWynn\Controllers\Website;
 
+use VoicesOfWynn\Models\Storage\Storage;
 use VoicesOfWynn\Models\Website\ContentManager;
 
 class Cast extends WebpageController
@@ -49,7 +50,15 @@ class Cast extends WebpageController
 			}
 		}
 		self::$data['cast_npc_groups'] = array_values($npcGroups);
-		self::$data['cast_scripted_quests'] = $cnm->getWritersQuests($contributorId);
+		$scriptedQuests = $cnm->getWritersQuests($contributorId);
+		$storage = Storage::get();
+		$scriptUrls = [];
+		foreach ($scriptedQuests as $q) {
+			$key = 'scripts/' . $q->getDegeneratedName() . '.txt';
+			$scriptUrls[$q->getId()] = $storage->exists($key) ? $storage->getUrl($key) : null;
+		}
+		self::$data['cast_scripted_quests'] = $scriptedQuests;
+		self::$data['cast_script_urls'] = $scriptUrls;
 		self::$data['cast_edited_npcs'] = $cnm->getEditorsNpcsByQuests($contributorId);
 
         $uuid = $this->loadUUID(); //Also saves UUID in $_SESSION

--- a/Controllers/Website/Cast.php
+++ b/Controllers/Website/Cast.php
@@ -54,8 +54,7 @@ class Cast extends WebpageController
 		$storage = Storage::get();
 		$scriptUrls = [];
 		foreach ($scriptedQuests as $q) {
-			$key = 'scripts/' . $q->getDegeneratedName() . '.txt';
-			$scriptUrls[$q->getId()] = $storage->exists($key) ? $storage->getUrl($key) : null;
+			$scriptUrls[$q->getId()] = $q->getScriptUrl($storage);
 		}
 		self::$data['cast_scripted_quests'] = $scriptedQuests;
 		self::$data['cast_script_urls'] = $scriptUrls;

--- a/Controllers/Website/Quest.php
+++ b/Controllers/Website/Quest.php
@@ -2,6 +2,7 @@
 
 namespace VoicesOfWynn\Controllers\Website;
 
+use VoicesOfWynn\Models\Storage\Storage;
 use VoicesOfWynn\Models\Website\ContentManager;
 use VoicesOfWynn\Models\Website\Quest AS QuestModel;
 
@@ -57,6 +58,10 @@ class Quest extends WebpageController
         self::$data['quest_uuid'] = $uuid;
         self::$data['quest_upvoted'] = $cnm->getVotes(hash('sha256', $uuid ?? $_SERVER['REMOTE_ADDR']), '+', $this->quest);
         self::$data['quest_downvoted'] = $cnm->getVotes(hash('sha256', $uuid ?? $_SERVER['REMOTE_ADDR']), '-', $this->quest);
+
+        $storage = Storage::get();
+        $scriptPath = 'scripts/' . $this->quest->getDegeneratedName() . '.txt';
+        self::$data['quest_script_url'] = $storage->exists($scriptPath) ? $storage->getUrl($scriptPath) : null;
 
         self::$views[] = 'quest';
         self::$cssFiles[] = 'quest';

--- a/Controllers/Website/Quest.php
+++ b/Controllers/Website/Quest.php
@@ -59,9 +59,7 @@ class Quest extends WebpageController
         self::$data['quest_upvoted'] = $cnm->getVotes(hash('sha256', $uuid ?? $_SERVER['REMOTE_ADDR']), '+', $this->quest);
         self::$data['quest_downvoted'] = $cnm->getVotes(hash('sha256', $uuid ?? $_SERVER['REMOTE_ADDR']), '-', $this->quest);
 
-        $storage = Storage::get();
-        $scriptPath = 'scripts/' . $this->quest->getDegeneratedName() . '.txt';
-        self::$data['quest_script_url'] = $storage->exists($scriptPath) ? $storage->getUrl($scriptPath) : null;
+        self::$data['quest_script_url'] = $this->quest->getScriptUrl(Storage::get());
 
         self::$views[] = 'quest';
         self::$cssFiles[] = 'quest';

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -223,15 +223,6 @@ class ContentManager
         return $result === false ? [] : $result;
     }
 
-    public function getQuestDegeneratedName(int $questId): ?string
-    {
-        $result = (new Db('Website/DbInfo.ini'))->fetchQuery(
-            'SELECT degenerated_name FROM quest WHERE quest_id = ?;',
-            [$questId]
-        );
-        return $result['degenerated_name'] ?? null;
-    }
-
     public function countQuests(): int
     {
         $result = (new Db('Website/DbInfo.ini'))->fetchQuery(
@@ -297,22 +288,6 @@ class ContentManager
             }
         }
         return array_values($quests);
-    }
-
-    public function setQuestWriter(int $questId, ?int $writerId): bool
-    {
-        return (new Db('Website/DbInfo.ini'))->executeQuery(
-            'UPDATE quest SET writer = ? WHERE quest_id = ?;',
-            [$writerId, $questId]
-        );
-    }
-
-    public function setNpcEditor(int $questId, int $npcId, ?int $editorId): bool
-    {
-        return (new Db('Website/DbInfo.ini'))->executeQuery(
-            'UPDATE npc_quest SET editor = ? WHERE quest_id = ? AND npc_id = ?;',
-            [$editorId, $questId, $npcId]
-        );
     }
 
     public function getEditorsNpcsByQuests(int $editorId) : array

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -223,6 +223,15 @@ class ContentManager
         return $result === false ? [] : $result;
     }
 
+    public function getQuestDegeneratedName(int $questId): ?string
+    {
+        $result = (new Db('Website/DbInfo.ini'))->fetchQuery(
+            'SELECT degenerated_name FROM quest WHERE quest_id = ?;',
+            [$questId]
+        );
+        return $result['degenerated_name'] ?? null;
+    }
+
     public function countQuests(): int
     {
         $result = (new Db('Website/DbInfo.ini'))->fetchQuery(
@@ -254,8 +263,8 @@ class ContentManager
                 editor.user_id AS \"editor_id\", editor.display_name AS \"editor_name\"
             FROM quest
             LEFT JOIN user writer ON writer.user_id = quest.writer
-            JOIN npc_quest ON npc_quest.quest_id = quest.quest_id
-            JOIN npc ON npc.npc_id = npc_quest.npc_id
+            LEFT JOIN npc_quest ON npc_quest.quest_id = quest.quest_id
+            LEFT JOIN npc ON npc.npc_id = npc_quest.npc_id
             LEFT JOIN user editor ON editor.user_id = npc_quest.editor
             WHERE quest.quest_id IN ($placeholders)
             ORDER BY quest.quest_id, npc_quest.sorting_order;
@@ -278,12 +287,14 @@ class ContentManager
                     'npcs' => [],
                 ];
             }
-            $quests[$questId]['npcs'][] = [
-                'id' => $row['npc_id'],
-                'name' => $row['nname'],
-                'editor_id' => $row['editor_id'],
-                'editor_name' => $row['editor_name'],
-            ];
+            if ($row['npc_id'] !== null) {
+                $quests[$questId]['npcs'][] = [
+                    'id' => $row['npc_id'],
+                    'name' => $row['nname'],
+                    'editor_id' => $row['editor_id'],
+                    'editor_name' => $row['editor_name'],
+                ];
+            }
         }
         return array_values($quests);
     }

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -199,6 +199,96 @@ class ContentManager
         return array_map(function($record) { return new Quest($record); }, $result);
     }
 
+    public function getUsersForDropdown(): array
+    {
+        $result = (new Db('Website/DbInfo.ini'))->fetchQuery(
+            'SELECT user_id, display_name FROM user ORDER BY display_name;',
+            [], true
+        );
+        return $result === false ? [] : $result;
+    }
+
+    public function countQuests(): int
+    {
+        $result = (new Db('Website/DbInfo.ini'))->fetchQuery(
+            'SELECT COUNT(*) AS cnt FROM quest;', []
+        );
+        return (int)($result['cnt'] ?? 0);
+    }
+
+    public function getQuestsWithCredits(int $page = 1, int $perPage = 25): array
+    {
+        $offset = ($page - 1) * $perPage;
+
+        $idRows = (new Db('Website/DbInfo.ini'))->fetchQuery(
+            'SELECT quest_id FROM quest ORDER BY quest_id LIMIT ? OFFSET ?;',
+            [$perPage, $offset], true
+        );
+        if (empty($idRows) || $idRows === false) {
+            return [];
+        }
+
+        $ids = array_column($idRows, 'quest_id');
+        $placeholders = implode(',', array_fill(0, count($ids), '?'));
+
+        $result = (new Db('Website/DbInfo.ini'))->fetchQuery("
+            SELECT
+                quest.quest_id, quest.name AS \"qname\", quest.degenerated_name,
+                writer.user_id AS \"writer_id\", writer.display_name AS \"writer_name\",
+                npc.npc_id, npc.name AS \"nname\",
+                editor.user_id AS \"editor_id\", editor.display_name AS \"editor_name\"
+            FROM quest
+            LEFT JOIN user writer ON writer.user_id = quest.writer
+            JOIN npc_quest ON npc_quest.quest_id = quest.quest_id
+            JOIN npc ON npc.npc_id = npc_quest.npc_id
+            LEFT JOIN user editor ON editor.user_id = npc_quest.editor
+            WHERE quest.quest_id IN ($placeholders)
+            ORDER BY quest.quest_id, npc_quest.sorting_order;
+        ", $ids, true);
+
+        if ($result === false) {
+            return [];
+        }
+
+        $quests = [];
+        foreach ($result as $row) {
+            $questId = $row['quest_id'];
+            if (!isset($quests[$questId])) {
+                $quests[$questId] = [
+                    'id' => $questId,
+                    'name' => $row['qname'],
+                    'degenerated_name' => $row['degenerated_name'],
+                    'writer_id' => $row['writer_id'],
+                    'writer_name' => $row['writer_name'],
+                    'npcs' => [],
+                ];
+            }
+            $quests[$questId]['npcs'][] = [
+                'id' => $row['npc_id'],
+                'name' => $row['nname'],
+                'editor_id' => $row['editor_id'],
+                'editor_name' => $row['editor_name'],
+            ];
+        }
+        return array_values($quests);
+    }
+
+    public function setQuestWriter(int $questId, ?int $writerId): bool
+    {
+        return (new Db('Website/DbInfo.ini'))->executeQuery(
+            'UPDATE quest SET writer = ? WHERE quest_id = ?;',
+            [$writerId, $questId]
+        );
+    }
+
+    public function setNpcEditor(int $questId, int $npcId, ?int $editorId): bool
+    {
+        return (new Db('Website/DbInfo.ini'))->executeQuery(
+            'UPDATE npc_quest SET editor = ? WHERE quest_id = ? AND npc_id = ?;',
+            [$editorId, $questId, $npcId]
+        );
+    }
+
     public function getEditorsNpcsByQuests(int $editorId) : array
     {
         $query = '

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -87,7 +87,7 @@ class ContentManager
 		FROM npc_quest
 		JOIN user ON user.user_id = npc_quest.editor
 		WHERE npc_quest.npc_id = ?;', array($id), true);
-		if (is_array($seResult)) {
+		if ($seResult !== false) {
 			foreach ($seResult as $seRow) {
 				$se = new User();
 				$se->setData(['id' => $seRow['se_id'], 'name' => $seRow['se_name'], 'avatar' => $seRow['se_picture']]);

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -63,13 +63,14 @@ class ContentManager
 
 	public function getNpc($id)
 	{
+		$db = new Db('Website/DbInfo.ini');
 		$query = '
 		SELECT npc.npc_id, npc.name, user.user_id, user.display_name, user.picture, npc.archived, npc.upvotes, npc.downvotes,
 		(SELECT COUNT(*) FROM comment WHERE comment.npc_id = npc.npc_id) AS comments
 		FROM npc
 		LEFT JOIN user ON npc.voice_actor_id = user.user_id
 		WHERE npc_id = ?;';
-		$result = (new Db('Website/DbInfo.ini'))->fetchQuery($query, array($id));
+		$result = $db->fetchQuery($query, array($id));
 
 		if ($result === false) {
 			return false;
@@ -80,6 +81,20 @@ class ContentManager
 			$voiceActor->setData($result);
 			$npc->setVoiceActor($voiceActor);
 		}
+
+		$seResult = $db->fetchQuery('
+		SELECT npc_quest.quest_id, user.user_id AS se_id, user.display_name AS se_name, user.picture AS se_picture
+		FROM npc_quest
+		JOIN user ON user.user_id = npc_quest.editor
+		WHERE npc_quest.npc_id = ?;', array($id), true);
+		if (is_array($seResult)) {
+			foreach ($seResult as $seRow) {
+				$se = new User();
+				$se->setData(['id' => $seRow['se_id'], 'name' => $seRow['se_name'], 'avatar' => $seRow['se_picture']]);
+				$npc->setSoundEditor(new Quest(['quest_id' => $seRow['quest_id']]), $se);
+			}
+		}
+
 		return $npc;
 	}
 

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -276,22 +276,26 @@ class ContentManager
         foreach ($result as $row) {
             $questId = $row['quest_id'];
             if (!isset($quests[$questId])) {
-                $quests[$questId] = [
-                    'id' => $questId,
-                    'name' => $row['qname'],
+                $questData = [
+                    'id'               => $questId,
+                    'name'             => $row['qname'],
                     'degenerated_name' => $row['degenerated_name'],
-                    'writer_id' => $row['writer_id'],
-                    'writer_name' => $row['writer_name'],
-                    'npcs' => [],
                 ];
+                if ($row['writer_id'] !== null) {
+                    $writer = new User();
+                    $writer->setData(['id' => $row['writer_id'], 'name' => $row['writer_name']]);
+                    $questData['writer'] = $writer;
+                }
+                $quests[$questId] = new Quest($questData);
             }
             if ($row['npc_id'] !== null) {
-                $quests[$questId]['npcs'][] = [
-                    'id' => $row['npc_id'],
-                    'name' => $row['nname'],
-                    'editor_id' => $row['editor_id'],
-                    'editor_name' => $row['editor_name'],
-                ];
+                $npc = new Npc(['npc_id' => $row['npc_id'], 'nname' => $row['nname']]);
+                if ($row['editor_id'] !== null) {
+                    $editor = new User();
+                    $editor->setData(['id' => $row['editor_id'], 'name' => $row['editor_name']]);
+                    $npc->setSoundEditor($quests[$questId], $editor);
+                }
+                $quests[$questId]->addNpc($npc);
             }
         }
         return array_values($quests);

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -4,6 +4,13 @@ namespace VoicesOfWynn\Models\Website;
 
 use VoicesOfWynn\Models\Db;
 
+/**
+ * Provides cross-cutting read operations that span multiple domain models
+ * (e.g. Quest + NPC + User in a single query).
+ *
+ * Keep this class thin. Do NOT add methods that operate on a single domain
+ * object — those belong on the relevant model (Quest, Npc, User, etc.).
+ */
 class ContentManager
 {
 	/**

--- a/Models/Website/ContentManager.php
+++ b/Models/Website/ContentManager.php
@@ -94,7 +94,7 @@ class ContentManager
 		FROM npc_quest
 		JOIN user ON user.user_id = npc_quest.editor
 		WHERE npc_quest.npc_id = ?;', array($id), true);
-		if ($seResult !== false) {
+		if ($seResult) {
 			foreach ($seResult as $seRow) {
 				$se = new User();
 				$se->setData(['id' => $seRow['se_id'], 'name' => $seRow['se_name'], 'avatar' => $seRow['se_picture']]);

--- a/Models/Website/Quest.php
+++ b/Models/Website/Quest.php
@@ -60,6 +60,49 @@ class Quest implements JsonSerializable
 	}
 
     /**
+     * Loads basic quest data by ID from the database.
+     * @return static|null The Quest object, or NULL if no quest with the given ID exists
+     */
+    public static function findById(int $id): ?static
+    {
+        $result = (new Db('Website/DbInfo.ini'))->fetchQuery(
+            'SELECT quest_id, name, degenerated_name FROM quest WHERE quest_id = ?;',
+            [$id]
+        );
+        if ($result === false) {
+            return null;
+        }
+        return new static($result);
+    }
+
+    /**
+     * Updates the script writer for this quest in the database
+     * @param int|null $writerId ID of the user to set as writer, or NULL to clear
+     * @return bool Whether the database query was successful
+     */
+    public function setWriter(?int $writerId): bool
+    {
+        return (new Db('Website/DbInfo.ini'))->executeQuery(
+            'UPDATE quest SET writer = ? WHERE quest_id = ?;',
+            [$writerId, $this->id]
+        );
+    }
+
+    /**
+     * Updates the sound editor for a specific NPC in this quest in the database
+     * @param int $npcId ID of the NPC whose editor to update
+     * @param int|null $editorId ID of the user to set as editor, or NULL to clear
+     * @return bool Whether the database query was successful
+     */
+    public function setNpcEditor(int $npcId, ?int $editorId): bool
+    {
+        return (new Db('Website/DbInfo.ini'))->executeQuery(
+            'UPDATE npc_quest SET editor = ? WHERE quest_id = ? AND npc_id = ?;',
+            [$editorId, $this->id, $npcId]
+        );
+    }
+
+    /**
      * Method loading quest ID and name from the database, filtering by the degenerated name that is already set
      * @return bool TRUE if data was loaded, FALSE if not (quest having the set degenerated name couldn't be found)
      */

--- a/Models/Website/Quest.php
+++ b/Models/Website/Quest.php
@@ -181,9 +181,10 @@ class Quest implements JsonSerializable
     /**
      * Returns the URL of this quest's script file, or NULL if no script has been uploaded yet
      */
-    public function getScriptUrl(Storage $storage): ?string
+    public function getScriptUrl(): ?string
     {
         $key = 'scripts/' . $this->degeneratedName . '.txt';
+        $storage = Storage::get();
         return $storage->exists($key) ? $storage->getUrl($key) : null;
     }
 

--- a/Models/Website/Quest.php
+++ b/Models/Website/Quest.php
@@ -4,6 +4,7 @@ namespace VoicesOfWynn\Models\Website;
 
 use \JsonSerializable;
 use VoicesOfWynn\Models\Db;
+use VoicesOfWynn\Models\Storage\Storage;
 
 class Quest implements JsonSerializable
 {
@@ -132,6 +133,15 @@ class Quest implements JsonSerializable
     public function getScriptAuthor() : ?User
     {
         return isset($this->scriptAuthor) ? $this->scriptAuthor : null;
+    }
+
+    /**
+     * Returns the URL of this quest's script file, or NULL if no script has been uploaded yet
+     */
+    public function getScriptUrl(Storage $storage): ?string
+    {
+        $key = 'scripts/' . $this->degeneratedName . '.txt';
+        return $storage->exists($key) ? $storage->getUrl($key) : null;
     }
 
     /**

--- a/Models/Website/Quest.php
+++ b/Models/Website/Quest.php
@@ -10,7 +10,7 @@ class Quest implements JsonSerializable
 	private int $id;
 	private ?string $name = null;
     private ?string $degeneratedName = null;
-    private User $scriptAuthor;
+    private ?User $scriptAuthor = null;
 
     private array $npcs;
 

--- a/Models/Website/Quest.php
+++ b/Models/Website/Quest.php
@@ -60,22 +60,6 @@ class Quest implements JsonSerializable
 	}
 
     /**
-     * Loads basic quest data by ID from the database.
-     * @return static|null The Quest object, or NULL if no quest with the given ID exists
-     */
-    public static function findById(int $id): ?static
-    {
-        $result = (new Db('Website/DbInfo.ini'))->fetchQuery(
-            'SELECT quest_id, name, degenerated_name FROM quest WHERE quest_id = ?;',
-            [$id]
-        );
-        if ($result === false) {
-            return null;
-        }
-        return new static($result);
-    }
-
-    /**
      * Updates the script writer for this quest in the database
      * @param int|null $writerId ID of the user to set as writer, or NULL to clear
      * @return bool Whether the database query was successful
@@ -112,17 +96,17 @@ class Quest implements JsonSerializable
     }
 
     /**
-     * Method loading quest ID and name from the database, filtering by the degenerated name that is already set
+     * Method loading quest data from the database, filtering by the degenerated name that is already set
      * @return bool TRUE if data was loaded, FALSE if not (quest having the set degenerated name couldn't be found)
      */
     public function loadFromDegeneratedName() : bool
     {
         if (!isset($this->degeneratedName)) {
-            throw new \BadMethodCallException('Method Quest::load mustn\'t be called when the Quest::degeneratedName attribute is not set.');
+            throw new \BadMethodCallException('Method Quest::loadFromDegeneratedName mustn\'t be called when the Quest::degeneratedName attribute is not set.');
         }
 
         $result = (new Db('Website/DbInfo.ini'))->fetchQuery('
-            SELECT quest_id, name, writer
+            SELECT quest_id, name, degenerated_name, writer
             FROM quest
             WHERE degenerated_name = ?;
         ', array($this->degeneratedName));
@@ -130,16 +114,45 @@ class Quest implements JsonSerializable
         if ($result === false) {
             return false;
         }
-        $this->id = $result['quest_id'];
-        $this->name = $result['name'];
-        if (is_null($result['writer'])) {
+        $this->loadQuestData($result);
+        return true;
+    }
+
+    /**
+     * Method loading quest data from the database, filtering by the ID that is already set
+     * @return bool TRUE if data was loaded, FALSE if not (quest having the set ID couldn't be found)
+     */
+    public function loadFromId() : bool
+    {
+        if (!isset($this->id)) {
+            throw new \BadMethodCallException('Method Quest::loadFromId mustn\'t be called when the Quest::id attribute is not set.');
+        }
+
+        $result = (new Db('Website/DbInfo.ini'))->fetchQuery('
+            SELECT quest_id, name, degenerated_name, writer
+            FROM quest
+            WHERE quest_id = ?;
+        ', array($this->id));
+
+        if ($result === false) {
+            return false;
+        }
+        $this->loadQuestData($result);
+        return true;
+    }
+
+    private function loadQuestData(array $data) : void
+    {
+        $this->id = $data['quest_id'];
+        $this->name = $data['name'];
+        $this->degeneratedName = $data['degenerated_name'];
+        if (is_null($data['writer'])) {
             $this->scriptAuthor = null;
         } else {
             $writer = new User();
-            $writer->setData(['id' => $result['writer']]);
+            $writer->setData(['id' => $data['writer']]);
             $this->scriptAuthor = $writer;
         }
-        return true;
     }
 	
 	/**

--- a/Models/Website/Quest.php
+++ b/Models/Website/Quest.php
@@ -106,7 +106,7 @@ class Quest implements JsonSerializable
         }
 
         $result = (new Db('Website/DbInfo.ini'))->fetchQuery('
-            SELECT quest_id, name, degenerated_name, writer
+            SELECT quest_id, name, writer
             FROM quest
             WHERE degenerated_name = ?;
         ', array($this->degeneratedName));
@@ -129,7 +129,7 @@ class Quest implements JsonSerializable
         }
 
         $result = (new Db('Website/DbInfo.ini'))->fetchQuery('
-            SELECT quest_id, name, degenerated_name, writer
+            SELECT name, degenerated_name, writer
             FROM quest
             WHERE quest_id = ?;
         ', array($this->id));
@@ -143,9 +143,9 @@ class Quest implements JsonSerializable
 
     private function loadQuestData(array $data) : void
     {
-        $this->id = $data['quest_id'];
+        $this->id = $data['quest_id'] ?? $this->id;
         $this->name = $data['name'];
-        $this->degeneratedName = $data['degenerated_name'];
+        $this->degeneratedName = $data['degenerated_name'] ?? $this->degeneratedName;
         if (is_null($data['writer'])) {
             $this->scriptAuthor = null;
         } else {

--- a/Models/Website/Quest.php
+++ b/Models/Website/Quest.php
@@ -22,6 +22,16 @@ class Quest implements JsonSerializable
 	 */
 	public function __construct(array $data)
 	{
+		$this->setData($data);
+	}
+
+	/**
+	 * Generic setter for all properties
+	 * @param array $data Associative array containing values to set. There are multiple allowed key names for each
+	 * attribute and any of the attributes can be omitted
+	 */
+	public function setData(array $data): void
+	{
 		foreach ($data as $key => $value) {
 			switch ($key) {
 				case 'id':
@@ -44,6 +54,7 @@ class Quest implements JsonSerializable
                         $this->scriptAuthor = $value;
                         break;
                     } else if (is_null($value)) {
+                        $this->scriptAuthor = null;
                         break;
                     }
                     $writer = new User();
@@ -114,7 +125,7 @@ class Quest implements JsonSerializable
         if ($result === false) {
             return false;
         }
-        $this->loadQuestData($result);
+        $this->setData($result);
         return true;
     }
 
@@ -137,22 +148,8 @@ class Quest implements JsonSerializable
         if ($result === false) {
             return false;
         }
-        $this->loadQuestData($result);
+        $this->setData($result);
         return true;
-    }
-
-    private function loadQuestData(array $data) : void
-    {
-        $this->id = $data['quest_id'] ?? $this->id;
-        $this->name = $data['name'];
-        $this->degeneratedName = $data['degenerated_name'] ?? $this->degeneratedName;
-        if (is_null($data['writer'])) {
-            $this->scriptAuthor = null;
-        } else {
-            $writer = new User();
-            $writer->setData(['id' => $data['writer']]);
-            $this->scriptAuthor = $writer;
-        }
     }
 	
 	/**

--- a/Models/Website/Quest.php
+++ b/Models/Website/Quest.php
@@ -96,7 +96,16 @@ class Quest implements JsonSerializable
      */
     public function setNpcEditor(int $npcId, ?int $editorId): bool
     {
-        return (new Db('Website/DbInfo.ini'))->executeQuery(
+        $db = new Db('Website/DbInfo.ini');
+        $npcQuest = $db->fetchQuery(
+            'SELECT npc_id FROM npc_quest WHERE quest_id = ? AND npc_id = ?;',
+            [$this->id, $npcId]
+        );
+        if ($npcQuest === false) {
+            return false;
+        }
+
+        return $db->executeQuery(
             'UPDATE npc_quest SET editor = ? WHERE quest_id = ? AND npc_id = ?;',
             [$editorId, $this->id, $npcId]
         );
@@ -247,4 +256,3 @@ class Quest implements JsonSerializable
         return true;
     }
 }
-

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ this will create all the containers (databases and everything) for you.
 
 Once the containers are running, you can access the following services:
 
-- **Website:** [http://localhost](http://localhost) or [http://127.0.0.1](http://127.0.0.1)  
+- **Website:** [http://localhost:8000](http://localhost:8000) or [http://127.0.0.1:8000](http://127.0.0.1:8000)  
   The main Voices of Wynn website will be available here.
 
 - **phpMyAdmin:** [http://localhost:8080](http://localhost:8080)  

--- a/Views/administration.phtml
+++ b/Views/administration.phtml
@@ -4,7 +4,7 @@
     <a href="/administration/npcs"> Manage NPCs </a>
     <a href="/administration/upload"> Upload recordings </a>
     <a href="/administration/new-release"> Create new release </a>
-    <a href="/administration/scripts"> Script credits </a>
+    <a href="/administration/scripts"> Quest credits </a>
 </nav>
 
 <?php require $this->getNextView(); ?>

--- a/Views/administration.phtml
+++ b/Views/administration.phtml
@@ -4,6 +4,7 @@
     <a href="/administration/npcs"> Manage NPCs </a>
     <a href="/administration/upload"> Upload recordings </a>
     <a href="/administration/new-release"> Create new release </a>
+    <a href="/administration/scripts"> Script credits </a>
 </nav>
 
 <?php require $this->getNextView(); ?>

--- a/Views/cast.phtml
+++ b/Views/cast.phtml
@@ -97,6 +97,7 @@ const SOCIAL_NAME = ['youtube' => 'YouTube', 'twitter' => 'Twitter', 'castingcal
 <?php endif ?>
 
 <?php $scriptedQuests = ${basename(__FILE__, '.phtml') . '_scripted_quests'}; ?>
+<?php $scriptUrls = ${basename(__FILE__, '.phtml') . '_script_urls'}; ?>
 <?php if (count($scriptedQuests) > 0): ?>
     <section class="cast-scripts-section">
         <h2 class="cast-section-title">Scriptwriting</h2>
@@ -104,7 +105,9 @@ const SOCIAL_NAME = ['youtube' => 'YouTube', 'twitter' => 'Twitter', 'castingcal
         <?php foreach ($scriptedQuests as $scriptedQuest) : ?>
             <div>
                 <a href="/contents/<?= $scriptedQuest->getDegeneratedName() ?>"><?= $scriptedQuest->getName() ?></a>
-                – <a href="<?= \VoicesOfWynn\storageUrl('scripts/' . $scriptedQuest->getDegeneratedName() . '.txt') ?>">Script file</a>
+                <?php if (!empty($scriptUrls[$scriptedQuest->getId()])): ?>
+                    – <a href="<?= htmlspecialchars($scriptUrls[$scriptedQuest->getId()]) ?>">Script file</a>
+                <?php endif ?>
             </div>
         <?php endforeach ?>
     </section>

--- a/Views/cast.phtml
+++ b/Views/cast.phtml
@@ -102,9 +102,9 @@ const SOCIAL_NAME = ['youtube' => 'YouTube', 'twitter' => 'Twitter', 'castingcal
         <h2 class="cast-section-title">Scriptwriting</h2>
 
         <?php foreach ($scriptedQuests as $scriptedQuest) : ?>
-            <div><!-- TODO @kmaxi integrate this into the frontend, create the scripts folder on the blob -->
-                <a href="/contents/<?= $scriptedQuest->getDegeneratedName() ?>"><?= $scriptedQuest->getName() ?></a> –
-                <a href="<?= \VoicesOfWynn\storageUrl('scripts/' . $scriptedQuest->getDegeneratedName() . '.txt') ?>">Script file</a>
+            <div>
+                <a href="/contents/<?= $scriptedQuest->getDegeneratedName() ?>"><?= $scriptedQuest->getName() ?></a>
+                – <a href="<?= \VoicesOfWynn\storageUrl('scripts/' . $scriptedQuest->getDegeneratedName() . '.txt') ?>">Script file</a>
             </div>
         <?php endforeach ?>
     </section>
@@ -116,8 +116,8 @@ const SOCIAL_NAME = ['youtube' => 'YouTube', 'twitter' => 'Twitter', 'castingcal
         <h2 class="cast-section-title">Sound Editing</h2>
 
         <?php foreach ($editedNpcs as $qnPair) : ?>
-            <div><!-- TODO @kmaxi integrate this into the frontend -->
-                <a href="/npc/<?= $qnPair['npc']->getId() ?>"><?= $qnPair['npc']->getName() ?></a>
+            <div>
+                <a href="/contents/npc/<?= $qnPair['npc']->getId() ?>"><?= $qnPair['npc']->getName() ?></a>
                 in
                 <a href="/contents/<?= $qnPair['quest']->getDegeneratedName() ?>"><?= $qnPair['quest']->getName() ?></a>
             </div>

--- a/Views/cast.phtml
+++ b/Views/cast.phtml
@@ -106,7 +106,7 @@ const SOCIAL_NAME = ['youtube' => 'YouTube', 'twitter' => 'Twitter', 'castingcal
             <div>
                 <a href="/contents/<?= $scriptedQuest->getDegeneratedName() ?>"><?= $scriptedQuest->getName() ?></a>
                 <?php if (!empty($scriptUrls[$scriptedQuest->getId()])): ?>
-                    – <a href="<?= htmlspecialchars($scriptUrls[$scriptedQuest->getId()]) ?>">Script file</a>
+                    – <a href="<?= $scriptUrls[$scriptedQuest->getId()] ?>">Script file</a>
                 <?php endif ?>
             </div>
         <?php endforeach ?>

--- a/Views/npc.phtml
+++ b/Views/npc.phtml
@@ -64,6 +64,7 @@ $cardIsDownvoted       = ${$prefix . 'was_downvoted'};
 $cardIsOpen            = false;
 $cardAdmin             = ${$prefix . 'admin'};
 $cardNpcId             = $cardNpc->getId();
+$cardShowSoundEditor   = true;
 ?>
 <?php include 'Views/partials/npc-card.phtml'; ?>
 <?php include 'Views/partials/comments-dialog.phtml'; ?>

--- a/Views/partials/npc-card.phtml
+++ b/Views/partials/npc-card.phtml
@@ -15,6 +15,8 @@ $cardAdmin = $cardAdmin ?? false;
 $cardShowFeaturedRecording = $cardShowFeaturedRecording ?? false;
 $cardShowQuestNames        = $cardShowQuestNames        ?? true;
 $cardShowVoiceActor        = $cardShowVoiceActor        ?? true;
+$cardShowSoundEditor       = $cardShowSoundEditor       ?? false;
+$cardQuestForSoundEditor   = $cardQuestForSoundEditor   ?? null;
 ?>
 <div class="cast-npc-block recording-actions<?= $cardIsOpen ? ' is-open' : '' ?>">
     <div class="cast-npc-header" role="button" tabindex="0" aria-expanded="<?= $cardIsOpen ? 'true' : 'false' ?>">
@@ -116,7 +118,42 @@ $cardShowVoiceActor        = $cardShowVoiceActor        ?? true;
                     <a href="/administration/upload?questId=<?= $questId ?>&amp;npcId=<?= $cardNpcId ?>" class="uploadbtn">Add new recordings</a>
                 </div>
             <?php endif ?>
-            <?php if ($multipleQuests): ?>
+            <?php if (!$multipleQuests && $cardShowSoundEditor):
+                  $allSe = $cardNpc->getSoundEditor();
+                  $se = $cardQuestForSoundEditor !== null
+                      ? $cardNpc->getSoundEditor($cardQuestForSoundEditor)
+                      : (is_array($allSe) ? reset($allSe) : $allSe);
+                  if ($se !== null): ?>
+            <div class="cast-npc-se-row">
+                <span class="cast-npc-se-label">Edited by</span>
+                <a href="/cast/<?= $se->getId() ?>" class="cast-npc-se-link--pic">
+                    <img class="cast-npc-se-avatar"
+                         src="<?= \VoicesOfWynn\storageUrl('avatars/' . $se->getAvatar()) ?>"
+                         onerror="this.onerror=null; this.src='<?= \VoicesOfWynn\storageUrl('avatars/default.png') ?>'"
+                         alt="Profile picture" loading="lazy" />
+                </a>
+                <a href="/cast/<?= $se->getId() ?>" class="cast-npc-se-name">
+                    <?= htmlspecialchars($se->getName()) ?>
+                </a>
+            </div>
+            <?php endif; endif ?>
+            <?php if ($multipleQuests):
+                  $allSoundEditors = $cardNpc->getSoundEditor();
+                  $se = $cardShowSoundEditor && is_array($allSoundEditors) ? ($allSoundEditors[$questId] ?? null) : null;
+                  if ($se !== null): ?>
+                <div class="cast-npc-se-row">
+                    <span class="cast-npc-se-label">Edited by</span>
+                    <a href="/cast/<?= $se->getId() ?>" class="cast-npc-se-link--pic">
+                        <img class="cast-npc-se-avatar"
+                             src="<?= \VoicesOfWynn\storageUrl('avatars/' . $se->getAvatar()) ?>"
+                             onerror="this.onerror=null; this.src='<?= \VoicesOfWynn\storageUrl('avatars/default.png') ?>'"
+                             alt="Profile picture" loading="lazy" />
+                    </a>
+                    <a href="/cast/<?= $se->getId() ?>" class="cast-npc-se-name">
+                        <?= htmlspecialchars($se->getName()) ?>
+                    </a>
+                </div>
+                <?php endif ?>
                 </div>
             <?php endif ?>
         <?php endforeach ?>

--- a/Views/partials/npc-card.phtml
+++ b/Views/partials/npc-card.phtml
@@ -122,7 +122,7 @@ $cardQuestForSoundEditor   = $cardQuestForSoundEditor   ?? null;
                   $allSe = $cardNpc->getSoundEditor();
                   $se = $cardQuestForSoundEditor !== null
                       ? $cardNpc->getSoundEditor($cardQuestForSoundEditor)
-                      : (is_array($allSe) ? reset($allSe) : $allSe);
+                      : (is_array($allSe) ? (reset($allSe) ?: null) : $allSe);
                   if ($se !== null): ?>
             <div class="cast-npc-se-row">
                 <span class="cast-npc-se-label">Edited by</span>

--- a/Views/partials/npc-card.phtml
+++ b/Views/partials/npc-card.phtml
@@ -26,7 +26,7 @@ $cardQuestForSoundEditor   = $cardQuestForSoundEditor   ?? null;
                     class="cast-npc-pic"
                     src="<?= \VoicesOfWynn\storageUrl('npcs/' . $cardNpc->getId() . '.webp') ?>"
                     onerror="this.onerror=null; this.src='<?= \VoicesOfWynn\storageUrl('npcs/default.webp') ?>'"
-                    alt="<?= htmlspecialchars($cardNpc->getName()) ?>"
+                    alt="<?= $cardNpc->getName() ?>"
                     loading="lazy"
                 />
             </a>
@@ -133,7 +133,7 @@ $cardQuestForSoundEditor   = $cardQuestForSoundEditor   ?? null;
                          alt="Profile picture" loading="lazy" />
                 </a>
                 <a href="/cast/<?= $se->getId() ?>" class="cast-npc-se-name">
-                    <?= htmlspecialchars($se->getName()) ?>
+                    <?= $se->getName() ?>
                 </a>
             </div>
             <?php endif; endif ?>
@@ -150,7 +150,7 @@ $cardQuestForSoundEditor   = $cardQuestForSoundEditor   ?? null;
                              alt="Profile picture" loading="lazy" />
                     </a>
                     <a href="/cast/<?= $se->getId() ?>" class="cast-npc-se-name">
-                        <?= htmlspecialchars($se->getName()) ?>
+                        <?= $se->getName() ?>
                     </a>
                 </div>
                 <?php endif ?>

--- a/Views/quest.phtml
+++ b/Views/quest.phtml
@@ -34,16 +34,24 @@
         <?php endforeach ?>
     </div>
 
+    <?php
+    $hasScriptAuthor = !is_null($quest->getScriptAuthor());
+    $soundEditors = array_filter($quest->getNpcs(), fn($npc) => !is_null($npc->getSoundEditor($quest)));
+    ?>
+    <?php if ($hasScriptAuthor || !empty($soundEditors)): ?>
     <h2>Processing</h2>
-    <?php if (!is_null($quest->getScriptAuthor())) : ?>
-        <div>Script by <a href="/cast/<?= $quest->getScriptAuthor()->getId() ?>"><?= $quest->getScriptAuthor()->getName() ?></a></div><!-- TODO @kmaxi integrate this into the frontend -->
+    <?php if ($hasScriptAuthor): ?>
+        <div>Script by <a href="/cast/<?= $quest->getScriptAuthor()->getId() ?>"><?= htmlspecialchars($quest->getScriptAuthor()->getName()) ?></a></div>
     <?php endif ?>
-    <div>
-        Sound editing by<br><!-- TODO @kmaxi integrate this into frontend -->
-        <?php foreach ($quest->getNpcs() as $npc) : ?>
-            <?php if (is_null($npc->getSoundEditor($quest))) { continue; } ?>
-            <a href="/cast/<?= $npc->getSoundEditor($quest)->getId() ?>"><?= $npc->getSoundEditor($quest)->getName() ?></a> (<a href="/npc/<?= $npc->getId() ?>"><?= $npc->getName() ?></a>)<br>
-        <?php endforeach ?>
-    </div>
+    <?php if (!empty($soundEditors)): ?>
+        <div>
+            Sound editing by<br>
+            <?php foreach ($soundEditors as $npc): ?>
+                <a href="/cast/<?= $npc->getSoundEditor($quest)->getId() ?>"><?= htmlspecialchars($npc->getSoundEditor($quest)->getName()) ?></a>
+                (<a href="/contents/npc/<?= $npc->getId() ?>"><?= htmlspecialchars($npc->getName()) ?></a>)<br>
+            <?php endforeach ?>
+        </div>
+    <?php endif ?>
+    <?php endif ?>
 </section>
 <?php include 'Views/partials/comments-dialog.phtml'; ?>

--- a/Views/quest.phtml
+++ b/Views/quest.phtml
@@ -38,10 +38,14 @@
     $hasScriptAuthor = !is_null($quest->getScriptAuthor());
     $soundEditors = array_filter($quest->getNpcs(), fn($npc) => !is_null($npc->getSoundEditor($quest)));
     ?>
-    <?php if ($hasScriptAuthor || !empty($soundEditors)): ?>
+    <?php $quest_script_url = ${basename(__FILE__, '.phtml').'_script_url'} ?>
+    <?php if ($hasScriptAuthor || !empty($soundEditors) || !is_null($quest_script_url)): ?>
     <h2>Processing</h2>
     <?php if ($hasScriptAuthor): ?>
         <div>Script by <a href="/cast/<?= $quest->getScriptAuthor()->getId() ?>"><?= htmlspecialchars($quest->getScriptAuthor()->getName()) ?></a></div>
+    <?php endif ?>
+    <?php if (!is_null($quest_script_url)): ?>
+        <div><a href="<?= htmlspecialchars($quest_script_url) ?>" download>Download script</a></div>
     <?php endif ?>
     <?php if (!empty($soundEditors)): ?>
         <div>

--- a/Views/quest.phtml
+++ b/Views/quest.phtml
@@ -29,6 +29,8 @@
             $cardShowFeaturedRecording    = true;
             $cardShowQuestNames           = false;
             $cardShowVoiceActor           = true;
+            $cardShowSoundEditor          = true;
+            $cardQuestForSoundEditor      = $quest;
             ?>
             <?php include 'Views/partials/npc-card.phtml'; ?>
         <?php endforeach ?>
@@ -36,26 +38,82 @@
 
     <?php
     $hasScriptAuthor = !is_null($quest->getScriptAuthor());
-    $soundEditors = array_filter($quest->getNpcs(), fn($npc) => !is_null($npc->getSoundEditor($quest)));
+    $editorMap = [];
+    foreach ($quest->getNpcs() as $npc) {
+        $se = $npc->getSoundEditor($quest);
+        if (!is_null($se)) {
+            $id = $se->getId();
+            if (!isset($editorMap[$id])) {
+                $editorMap[$id] = ['editor' => $se, 'npcs' => []];
+            }
+            $editorMap[$id]['npcs'][] = $npc;
+        }
+    }
     ?>
     <?php $quest_script_url = ${basename(__FILE__, '.phtml').'_script_url'} ?>
-    <?php if ($hasScriptAuthor || !empty($soundEditors) || !is_null($quest_script_url)): ?>
-    <h2>Processing</h2>
-    <?php if ($hasScriptAuthor): ?>
-        <div>Script by <a href="/cast/<?= $quest->getScriptAuthor()->getId() ?>"><?= htmlspecialchars($quest->getScriptAuthor()->getName()) ?></a></div>
-    <?php endif ?>
-    <?php if (!is_null($quest_script_url)): ?>
-        <div><a href="<?= htmlspecialchars($quest_script_url) ?>" download>Download script</a></div>
-    <?php endif ?>
-    <?php if (!empty($soundEditors)): ?>
-        <div>
-            Sound editing by<br>
-            <?php foreach ($soundEditors as $npc): ?>
-                <a href="/cast/<?= $npc->getSoundEditor($quest)->getId() ?>"><?= htmlspecialchars($npc->getSoundEditor($quest)->getName()) ?></a>
-                (<a href="/contents/npc/<?= $npc->getId() ?>"><?= htmlspecialchars($npc->getName()) ?></a>)<br>
-            <?php endforeach ?>
+    <?php if ($hasScriptAuthor || !empty($editorMap) || !is_null($quest_script_url)): ?>
+    <div class="quest-processing">
+        <h2 class="quest-section-title txt-c">Processing</h2>
+
+        <?php if ($hasScriptAuthor): ?>
+        <?php $writer = $quest->getScriptAuthor(); ?>
+        <div class="quest-processing-writer">
+            <a href="/cast/<?= $writer->getId() ?>" class="quest-processing-avatar-link">
+                <img class="quest-processing-avatar"
+                     src="<?= \VoicesOfWynn\storageUrl('avatars/' . $writer->getAvatar()) ?>"
+                     onerror="this.onerror=null; this.src='<?= \VoicesOfWynn\storageUrl('avatars/default.png') ?>'"
+                     alt="Profile picture" loading="lazy" />
+            </a>
+            <div class="quest-processing-writer-info">
+                <span class="quest-processing-role">Script by</span>
+                <a href="/cast/<?= $writer->getId() ?>" class="quest-processing-name">
+                    <?= htmlspecialchars($writer->getName()) ?>
+                </a>
+            </div>
+            <?php if (!is_null($quest_script_url)): ?>
+            <a href="<?= htmlspecialchars($quest_script_url) ?>" target="_blank" rel="noopener noreferrer"
+               class="quest-view-script-btn">View script</a>
+            <?php endif ?>
         </div>
-    <?php endif ?>
+        <?php elseif (!is_null($quest_script_url)): ?>
+        <div class="quest-processing-writer">
+            <a href="<?= htmlspecialchars($quest_script_url) ?>" target="_blank" rel="noopener noreferrer"
+               class="quest-view-script-btn">View script</a>
+        </div>
+        <?php endif ?>
+
+        <?php if (!empty($editorMap)): ?>
+        <div class="quest-processing-editors">
+            <h3 class="quest-processing-editors-title">Sound editing</h3>
+            <div class="quest-processing-editors-list">
+                <?php foreach ($editorMap as $entry):
+                      $se = $entry['editor'];
+                      $editorNpcs = $entry['npcs']; ?>
+                <div class="quest-processing-editor-card">
+                    <a href="/cast/<?= $se->getId() ?>" class="quest-processing-avatar-link">
+                        <img class="quest-processing-avatar"
+                             src="<?= \VoicesOfWynn\storageUrl('avatars/' . $se->getAvatar()) ?>"
+                             onerror="this.onerror=null; this.src='<?= \VoicesOfWynn\storageUrl('avatars/default.png') ?>'"
+                             alt="Profile picture" loading="lazy" />
+                    </a>
+                    <div class="quest-processing-editor-info">
+                        <a href="/cast/<?= $se->getId() ?>" class="quest-processing-name">
+                            <?= htmlspecialchars($se->getName()) ?>
+                        </a>
+                        <div class="quest-processing-editor-npcs">
+                            <?php foreach ($editorNpcs as $npc): ?>
+                            <a href="/contents/npc/<?= $npc->getId() ?>" class="quest-processing-npc-chip">
+                                <?= htmlspecialchars($npc->getName()) ?>
+                            </a>
+                            <?php endforeach ?>
+                        </div>
+                    </div>
+                </div>
+                <?php endforeach ?>
+            </div>
+        </div>
+        <?php endif ?>
+    </div>
     <?php endif ?>
 </section>
 <?php include 'Views/partials/comments-dialog.phtml'; ?>

--- a/Views/quest.phtml
+++ b/Views/quest.phtml
@@ -67,17 +67,17 @@
             <div class="quest-processing-writer-info">
                 <span class="quest-processing-role">Script by</span>
                 <a href="/cast/<?= $writer->getId() ?>" class="quest-processing-name">
-                    <?= htmlspecialchars($writer->getName()) ?>
+                    <?= $writer->getName() ?>
                 </a>
             </div>
             <?php if (!is_null($quest_script_url)): ?>
-            <a href="<?= htmlspecialchars($quest_script_url) ?>" target="_blank" rel="noopener noreferrer"
+            <a href="<?= $quest_script_url ?>" target="_blank" rel="noopener noreferrer"
                class="quest-view-script-btn">View script</a>
             <?php endif ?>
         </div>
         <?php elseif (!is_null($quest_script_url)): ?>
         <div class="quest-processing-writer">
-            <a href="<?= htmlspecialchars($quest_script_url) ?>" target="_blank" rel="noopener noreferrer"
+            <a href="<?= $quest_script_url ?>" target="_blank" rel="noopener noreferrer"
                class="quest-view-script-btn">View script</a>
         </div>
         <?php endif ?>
@@ -98,12 +98,12 @@
                     </a>
                     <div class="quest-processing-editor-info">
                         <a href="/cast/<?= $se->getId() ?>" class="quest-processing-name">
-                            <?= htmlspecialchars($se->getName()) ?>
+                            <?= $se->getName() ?>
                         </a>
                         <div class="quest-processing-editor-npcs">
                             <?php foreach ($editorNpcs as $npc): ?>
                             <a href="/contents/npc/<?= $npc->getId() ?>" class="quest-processing-npc-chip">
-                                <?= htmlspecialchars($npc->getName()) ?>
+                                <?= $npc->getName() ?>
                             </a>
                             <?php endforeach ?>
                         </div>

--- a/Views/scripts.phtml
+++ b/Views/scripts.phtml
@@ -1,6 +1,7 @@
 <?php
 $quests      = ${basename(__FILE__, '.phtml') . '_quests'};
 $users       = ${basename(__FILE__, '.phtml') . '_users'};
+$storage     = ${basename(__FILE__, '.phtml') . '_storage'};
 $message     = ${basename(__FILE__, '.phtml') . '_message'};
 $error       = ${basename(__FILE__, '.phtml') . '_error'};
 $currentPage = ${basename(__FILE__, '.phtml') . '_current_page'};
@@ -23,34 +24,35 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
 
 <div id="quest-list">
 <?php foreach ($quests as $quest): ?>
-    <details class="box" data-quest-name="<?= strtolower(htmlspecialchars($quest['name'])) ?>">
+    <?php $scriptUrl = $quest->getScriptUrl($storage) ?>
+    <details class="box" data-quest-name="<?= strtolower(htmlspecialchars($quest->getName())) ?>">
         <summary style="font-weight:bold; cursor:pointer;">
-            <?= htmlspecialchars($quest['name']) ?>
-            <?php if ($quest['writer_name']): ?>
-                <span class="va-name"> — script by <?= htmlspecialchars($quest['writer_name']) ?></span>
+            <?= htmlspecialchars($quest->getName()) ?>
+            <?php if ($quest->getScriptAuthor()): ?>
+                <span class="va-name"> — script by <?= htmlspecialchars($quest->getScriptAuthor()->getName()) ?></span>
             <?php endif ?>
-            <?php if ($quest['has_script']): ?>
+            <?php if ($scriptUrl): ?>
                 <span style="color:green;"> ✓ script file</span>
             <?php endif ?>
         </summary>
 
         <form method="post" action="/administration/scripts" enctype="multipart/form-data">
             <input type="hidden" name="action" value="save-quest">
-            <input type="hidden" name="quest_id" value="<?= (int)$quest['id'] ?>">
-            <input type="hidden" name="degenerated_name" value="<?= htmlspecialchars($quest['degenerated_name']) ?>">
+            <input type="hidden" name="quest_id" value="<?= (int)$quest->getId() ?>">
+            <input type="hidden" name="degenerated_name" value="<?= htmlspecialchars($quest->getDegeneratedName()) ?>">
 
             <table style="margin:8px 0; border-spacing:6px 4px;">
                 <tr>
                     <td><strong>Writer:</strong></td>
                     <td>
-                        <?php if ($quest['writer_name']): ?>
-                            <a href="/cast/<?= (int)$quest['writer_id'] ?>"><?= htmlspecialchars($quest['writer_name']) ?></a>
+                        <?php if ($quest->getScriptAuthor()): ?>
+                            <a href="/cast/<?= (int)$quest->getScriptAuthor()->getId() ?>"><?= htmlspecialchars($quest->getScriptAuthor()->getName()) ?></a>
                         <?php else: ?>
                             <em>None</em>
                         <?php endif ?>
                     </td>
                     <td>
-                        <select name="writer_id" class="user-select" data-selected="<?= (int)$quest['writer_id'] ?>">
+                        <select name="writer_id" class="user-select" data-selected="<?= (int)$quest->getScriptAuthor()?->getId() ?>">
                             <option value="">— None —</option>
                         </select>
                     </td>
@@ -58,8 +60,8 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
                 <tr>
                     <td><strong>Script file:</strong></td>
                     <td>
-                        <?php if ($quest['has_script']): ?>
-                            <a href="<?= htmlspecialchars($quest['script_url']) ?>" target="_blank">View current</a>
+                        <?php if ($scriptUrl): ?>
+                            <a href="<?= htmlspecialchars($scriptUrl) ?>" target="_blank">View current</a>
                         <?php else: ?>
                             <em>Not uploaded</em>
                         <?php endif ?>
@@ -70,7 +72,7 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
                 </tr>
             </table>
 
-            <?php if (!empty($quest['npcs'])): ?>
+            <?php if ($quest->getNpcs()): ?>
                 <strong>Sound editors by NPC:</strong>
                 <table style="border-spacing:6px 3px;">
                     <tr>
@@ -78,19 +80,19 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
                         <th style="text-align:left;">Current editor</th>
                         <th></th>
                     </tr>
-                    <?php foreach ($quest['npcs'] as $npc): ?>
+                    <?php foreach ($quest->getNpcs() as $npc): ?>
                         <tr>
-                            <td class="npc-name"><?= htmlspecialchars($npc['name']) ?></td>
+                            <td class="npc-name"><?= htmlspecialchars($npc->getName()) ?></td>
                             <td>
-                                <?php if ($npc['editor_name']): ?>
-                                    <a href="/cast/<?= (int)$npc['editor_id'] ?>"><?= htmlspecialchars($npc['editor_name']) ?></a>
+                                <?php if ($npc->getSoundEditor($quest)): ?>
+                                    <a href="/cast/<?= (int)$npc->getSoundEditor($quest)->getId() ?>"><?= htmlspecialchars($npc->getSoundEditor($quest)->getName()) ?></a>
                                 <?php else: ?>
                                     <em>None</em>
                                 <?php endif ?>
                             </td>
                             <td>
-                                <select name="npc_editors[<?= (int)$npc['id'] ?>]" class="user-select"
-                                    data-selected="<?= (int)$npc['editor_id'] ?>">
+                                <select name="npc_editors[<?= (int)$npc->getId() ?>]" class="user-select"
+                                    data-selected="<?= (int)$npc->getSoundEditor($quest)?->getId() ?>">
                                     <option value="">— None —</option>
                                 </select>
                             </td>

--- a/Views/scripts.phtml
+++ b/Views/scripts.phtml
@@ -10,10 +10,10 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
 <h2 class="txt-c">Script Credits &amp; Sound Editors</h2>
 
 <?php if ($message): ?>
-    <p class="success"><?= htmlspecialchars($message) ?></p>
+    <p class="success"><?= $message ?></p>
 <?php endif ?>
 <?php if ($error): ?>
-    <p class="error"><?= htmlspecialchars($error) ?></p>
+    <p class="error"><?= $error ?></p>
 <?php endif ?>
 
 <p class="txt-c">

--- a/Views/scripts.phtml
+++ b/Views/scripts.phtml
@@ -1,7 +1,6 @@
 <?php
 $quests      = ${basename(__FILE__, '.phtml') . '_quests'};
 $users       = ${basename(__FILE__, '.phtml') . '_users'};
-$storage     = ${basename(__FILE__, '.phtml') . '_storage'};
 $message     = ${basename(__FILE__, '.phtml') . '_message'};
 $error       = ${basename(__FILE__, '.phtml') . '_error'};
 $currentPage = ${basename(__FILE__, '.phtml') . '_current_page'};
@@ -24,7 +23,7 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
 
 <div id="quest-list">
 <?php foreach ($quests as $quest): ?>
-    <?php $scriptUrl = $quest->getScriptUrl($storage) ?>
+    <?php $scriptUrl = $quest->getScriptUrl() ?>
     <details class="box" data-quest-name="<?= strtolower(htmlspecialchars($quest->getName())) ?>">
         <summary style="font-weight:bold; cursor:pointer;">
             <?= htmlspecialchars($quest->getName()) ?>

--- a/Views/scripts.phtml
+++ b/Views/scripts.phtml
@@ -1,0 +1,151 @@
+<?php
+$quests      = ${basename(__FILE__, '.phtml') . '_quests'};
+$users       = ${basename(__FILE__, '.phtml') . '_users'};
+$message     = ${basename(__FILE__, '.phtml') . '_message'};
+$error       = ${basename(__FILE__, '.phtml') . '_error'};
+$currentPage = ${basename(__FILE__, '.phtml') . '_current_page'};
+$totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
+?>
+
+<h2 class="txt-c">Script Credits &amp; Sound Editors</h2>
+
+<?php if ($message): ?>
+    <p class="success"><?= htmlspecialchars($message) ?></p>
+<?php endif ?>
+<?php if ($error): ?>
+    <p class="error"><?= htmlspecialchars($error) ?></p>
+<?php endif ?>
+
+<p class="txt-c">
+    <input type="text" id="quest-filter" placeholder="Filter quests by name…" oninput="filterQuests(this.value)"
+        style="width:20rem; padding:4px 8px;">
+</p>
+
+<div id="quest-list">
+<?php foreach ($quests as $quest): ?>
+    <details class="box" data-quest-name="<?= strtolower(htmlspecialchars($quest['name'])) ?>">
+        <summary style="font-weight:bold; cursor:pointer;">
+            <?= htmlspecialchars($quest['name']) ?>
+            <?php if ($quest['writer_name']): ?>
+                <span class="va-name"> — script by <?= htmlspecialchars($quest['writer_name']) ?></span>
+            <?php endif ?>
+            <?php if ($quest['has_script']): ?>
+                <span style="color:green;"> ✓ script file</span>
+            <?php endif ?>
+        </summary>
+
+        <form method="post" action="/administration/scripts" enctype="multipart/form-data">
+            <input type="hidden" name="action" value="save-quest">
+            <input type="hidden" name="quest_id" value="<?= (int)$quest['id'] ?>">
+            <input type="hidden" name="degenerated_name" value="<?= htmlspecialchars($quest['degenerated_name']) ?>">
+
+            <table style="margin:8px 0; border-spacing:6px 4px;">
+                <tr>
+                    <td><strong>Writer:</strong></td>
+                    <td>
+                        <?php if ($quest['writer_name']): ?>
+                            <a href="/cast/<?= (int)$quest['writer_id'] ?>"><?= htmlspecialchars($quest['writer_name']) ?></a>
+                        <?php else: ?>
+                            <em>None</em>
+                        <?php endif ?>
+                    </td>
+                    <td>
+                        <select name="writer_id" class="user-select" data-selected="<?= (int)$quest['writer_id'] ?>">
+                            <option value="">— None —</option>
+                        </select>
+                    </td>
+                </tr>
+                <tr>
+                    <td><strong>Script file:</strong></td>
+                    <td>
+                        <?php if ($quest['has_script']): ?>
+                            <a href="<?= htmlspecialchars($quest['script_url']) ?>" target="_blank">View current</a>
+                        <?php else: ?>
+                            <em>Not uploaded</em>
+                        <?php endif ?>
+                    </td>
+                    <td>
+                        <input type="file" name="script_file" accept="text/plain,.txt">
+                    </td>
+                </tr>
+            </table>
+
+            <?php if (!empty($quest['npcs'])): ?>
+                <strong>Sound editors by NPC:</strong>
+                <table style="border-spacing:6px 3px;">
+                    <tr>
+                        <th style="text-align:left;">NPC</th>
+                        <th style="text-align:left;">Current editor</th>
+                        <th></th>
+                    </tr>
+                    <?php foreach ($quest['npcs'] as $npc): ?>
+                        <tr>
+                            <td class="npc-name"><?= htmlspecialchars($npc['name']) ?></td>
+                            <td>
+                                <?php if ($npc['editor_name']): ?>
+                                    <a href="/cast/<?= (int)$npc['editor_id'] ?>"><?= htmlspecialchars($npc['editor_name']) ?></a>
+                                <?php else: ?>
+                                    <em>None</em>
+                                <?php endif ?>
+                            </td>
+                            <td>
+                                <select name="npc_editors[<?= (int)$npc['id'] ?>]" class="user-select"
+                                    data-selected="<?= (int)$npc['editor_id'] ?>">
+                                    <option value="">— None —</option>
+                                </select>
+                            </td>
+                        </tr>
+                    <?php endforeach ?>
+                </table>
+            <?php endif ?>
+
+            <div style="margin-top:8px;">
+                <button type="submit">Save all changes</button>
+            </div>
+        </form>
+    </details>
+<?php endforeach ?>
+</div>
+
+<?php if ($totalPages > 1): ?>
+<div style="text-align:center; margin-top:1rem;">
+    <?php if ($currentPage > 1): ?>
+        <a href="?page=<?= $currentPage - 1 ?>">&larr; Previous</a>
+    <?php endif ?>
+    &nbsp; Page <?= $currentPage ?> of <?= $totalPages ?> &nbsp;
+    <?php if ($currentPage < $totalPages): ?>
+        <a href="?page=<?= $currentPage + 1 ?>">Next &rarr;</a>
+    <?php endif ?>
+</div>
+<?php endif ?>
+
+<script>
+var USERS = <?= json_encode(array_map(fn($u) => ['id' => (int)$u['user_id'], 'name' => $u['display_name']], $users)) ?>;
+
+function populateSelects(details) {
+    details.querySelectorAll('select.user-select:not([data-populated])').forEach(function(sel) {
+        var selected = parseInt(sel.dataset.selected) || 0;
+        USERS.forEach(function(u) {
+            var opt = document.createElement('option');
+            opt.value = u.id;
+            opt.textContent = u.name;
+            if (u.id === selected) opt.selected = true;
+            sel.appendChild(opt);
+        });
+        sel.dataset.populated = '1';
+    });
+}
+
+document.querySelectorAll('#quest-list details').forEach(function(details) {
+    details.addEventListener('toggle', function() {
+        if (details.open) populateSelects(details);
+    });
+});
+
+function filterQuests(query) {
+    query = query.toLowerCase();
+    document.querySelectorAll('#quest-list details').forEach(function(el) {
+        el.style.display = el.dataset.questName.includes(query) ? '' : 'none';
+    });
+}
+</script>

--- a/Views/scripts.phtml
+++ b/Views/scripts.phtml
@@ -110,11 +110,11 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
 <?php if ($totalPages > 1): ?>
 <div style="text-align:center; margin-top:1rem;">
     <?php if ($currentPage > 1): ?>
-        <a href="?page=<?= $currentPage - 1 ?>">&larr; Previous</a>
+        <a href="/administration/scripts?page=<?= $currentPage - 1 ?>">&larr; Previous</a>
     <?php endif ?>
     &nbsp; Page <?= $currentPage ?> of <?= $totalPages ?> &nbsp;
     <?php if ($currentPage < $totalPages): ?>
-        <a href="?page=<?= $currentPage + 1 ?>">Next &rarr;</a>
+        <a href="/administration/scripts?page=<?= $currentPage + 1 ?>">Next &rarr;</a>
     <?php endif ?>
 </div>
 <?php endif ?>

--- a/Views/scripts.phtml
+++ b/Views/scripts.phtml
@@ -35,7 +35,7 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
             <?php endif ?>
         </summary>
 
-        <form method="post" action="/administration/scripts" enctype="multipart/form-data">
+        <form method="post" action="/administration/scripts?page=<?= $currentPage ?>" enctype="multipart/form-data">
             <input type="hidden" name="action" value="save-quest">
             <input type="hidden" name="quest_id" value="<?= (int)$quest->getId() ?>">
             <input type="hidden" name="degenerated_name" value="<?= $quest->getDegeneratedName() ?>">

--- a/Views/scripts.phtml
+++ b/Views/scripts.phtml
@@ -24,11 +24,11 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
 <div id="quest-list">
 <?php foreach ($quests as $quest): ?>
     <?php $scriptUrl = $quest->getScriptUrl() ?>
-    <details class="box" data-quest-name="<?= strtolower(htmlspecialchars($quest->getName())) ?>">
+    <details class="box" data-quest-name="<?= strtolower($quest->getName()) ?>">
         <summary style="font-weight:bold; cursor:pointer;">
-            <?= htmlspecialchars($quest->getName()) ?>
+            <?= $quest->getName() ?>
             <?php if ($quest->getScriptAuthor()): ?>
-                <span class="va-name"> — script by <?= htmlspecialchars($quest->getScriptAuthor()->getName()) ?></span>
+                <span class="va-name"> — script by <?= $quest->getScriptAuthor()->getName() ?></span>
             <?php endif ?>
             <?php if ($scriptUrl): ?>
                 <span style="color:green;"> ✓ script file</span>
@@ -38,14 +38,14 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
         <form method="post" action="/administration/scripts" enctype="multipart/form-data">
             <input type="hidden" name="action" value="save-quest">
             <input type="hidden" name="quest_id" value="<?= (int)$quest->getId() ?>">
-            <input type="hidden" name="degenerated_name" value="<?= htmlspecialchars($quest->getDegeneratedName()) ?>">
+            <input type="hidden" name="degenerated_name" value="<?= $quest->getDegeneratedName() ?>">
 
             <table style="margin:8px 0; border-spacing:6px 4px;">
                 <tr>
                     <td><strong>Writer:</strong></td>
                     <td>
                         <?php if ($quest->getScriptAuthor()): ?>
-                            <a href="/cast/<?= (int)$quest->getScriptAuthor()->getId() ?>"><?= htmlspecialchars($quest->getScriptAuthor()->getName()) ?></a>
+                            <a href="/cast/<?= (int)$quest->getScriptAuthor()->getId() ?>"><?= $quest->getScriptAuthor()->getName() ?></a>
                         <?php else: ?>
                             <em>None</em>
                         <?php endif ?>
@@ -60,7 +60,7 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
                     <td><strong>Script file:</strong></td>
                     <td>
                         <?php if ($scriptUrl): ?>
-                            <a href="<?= htmlspecialchars($scriptUrl) ?>" target="_blank">View current</a>
+                            <a href="<?= $scriptUrl ?>" target="_blank">View current</a>
                         <?php else: ?>
                             <em>Not uploaded</em>
                         <?php endif ?>
@@ -81,10 +81,10 @@ $totalPages  = ${basename(__FILE__, '.phtml') . '_total_pages'};
                     </tr>
                     <?php foreach ($quest->getNpcs() as $npc): ?>
                         <tr>
-                            <td class="npc-name"><?= htmlspecialchars($npc->getName()) ?></td>
+                            <td class="npc-name"><?= $npc->getName() ?></td>
                             <td>
                                 <?php if ($npc->getSoundEditor($quest)): ?>
-                                    <a href="/cast/<?= (int)$npc->getSoundEditor($quest)->getId() ?>"><?= htmlspecialchars($npc->getSoundEditor($quest)->getName()) ?></a>
+                                    <a href="/cast/<?= (int)$npc->getSoundEditor($quest)->getId() ?>"><?= $npc->getSoundEditor($quest)->getName() ?></a>
                                 <?php else: ?>
                                     <em>None</em>
                                 <?php endif ?>

--- a/css/npc-card.css
+++ b/css/npc-card.css
@@ -462,6 +462,8 @@ a.cast-npc-va-name:hover { color: var(--gradient-pink); }
 @media (prefers-reduced-motion: reduce) {
   .cast-npc-va-avatar { transition: none; }
   .cast-npc-va-link--pic:hover .cast-npc-va-avatar { transform: none; }
+  .cast-npc-se-avatar { transition: none; }
+  .cast-npc-se-link--pic:hover .cast-npc-se-avatar { transform: none; }
 }
 
 /* Responsive grid breakpoints for cast-npc-header */

--- a/css/npc-card.css
+++ b/css/npc-card.css
@@ -368,6 +368,47 @@
   border-top: 1px solid #eee;
 }
 
+/* Sound editor strip (shown at bottom of expanded card when $cardShowSoundEditor = true) */
+.cast-npc-se-row {
+  margin-top: 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.75rem;
+  background: rgba(123, 26, 155, 0.04);
+  border-radius: 0.625rem;
+  border-left: 3px solid var(--gradient-purple);
+}
+
+.cast-npc-se-label {
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+.cast-npc-se-link--pic { display: block; flex-shrink: 0; }
+
+.cast-npc-se-avatar {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid var(--gradient-purple);
+  transition: transform 0.2s ease;
+}
+
+.cast-npc-se-link--pic:hover .cast-npc-se-avatar { transform: scale(1.1); }
+
+.cast-npc-se-name {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--gradient-purple);
+  text-decoration: none;
+}
+
+.cast-npc-se-name:hover { color: var(--gradient-pink); }
+
 /* Featured recording (shown inline when $cardShowFeaturedRecording = true) */
 .cast-npc-featured-audio {
   grid-area: audio;

--- a/css/quest.css
+++ b/css/quest.css
@@ -10,3 +10,229 @@
   margin-left: auto;
   margin-right: auto;
 }
+
+/* Processing section */
+.quest-processing {
+  max-width: 960px;
+  margin: 2rem auto 0;
+}
+
+.quest-processing-writer {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(255, 255, 255, 0.98);
+  border-radius: 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 1rem 1.5rem;
+  margin-bottom: 1.25rem;
+  flex-wrap: wrap;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.quest-processing-writer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #7b1a9b, #ff6b9d);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+  z-index: 1;
+}
+
+.quest-processing-writer:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 20px rgba(123, 26, 155, 0.2);
+}
+
+.quest-processing-writer:hover::before {
+  transform: scaleX(1);
+}
+
+.quest-processing-avatar-link {
+  display: block;
+  flex-shrink: 0;
+}
+
+.quest-processing-avatar {
+  width: 64px;
+  height: 64px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid #7b1a9b;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.quest-processing-avatar-link:hover .quest-processing-avatar {
+  transform: scale(1.08);
+  box-shadow: 0 4px 12px rgba(123, 26, 155, 0.3);
+}
+
+.quest-processing-writer-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.quest-processing-role {
+  font-size: 0.8rem;
+  color: #666;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.quest-processing-name {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #7b1a9b;
+  text-decoration: none;
+}
+
+.quest-processing-name:hover { color: #a340c4; }
+
+.quest-view-script-btn {
+  background: linear-gradient(135deg, #7b1a9b, #a340c4);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 1.25rem;
+  border-radius: 0.5rem;
+  font-weight: 600;
+  font-size: 0.9rem;
+  text-decoration: none;
+  display: inline-block;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  white-space: nowrap;
+  margin-left: auto;
+}
+
+.quest-view-script-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 15px rgba(123, 26, 155, 0.4);
+}
+
+/* Sound editors list */
+.quest-processing-editors {
+  background: rgba(255, 255, 255, 0.98);
+  border-radius: 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  padding: 1.25rem 1.75rem 1.75rem;
+  position: relative;
+  overflow: hidden;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.quest-processing-editors::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 4px;
+  background: linear-gradient(90deg, #7b1a9b, #ff6b9d);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.3s ease;
+  z-index: 1;
+}
+
+.quest-processing-editors:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 6px 20px rgba(123, 26, 155, 0.2);
+}
+
+.quest-processing-editors:hover::before {
+  transform: scaleX(1);
+}
+
+.quest-processing-editors-title {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 1.25rem;
+  text-align: center;
+}
+
+.quest-processing-editors-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  justify-content: center;
+}
+
+.quest-processing-editor-card {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  background: rgba(123, 26, 155, 0.04);
+  border-radius: 0.75rem;
+  padding: 0.625rem 1rem 0.625rem 0.625rem;
+  min-width: 180px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+.quest-processing-editor-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px rgba(123, 26, 155, 0.15);
+  background: rgba(123, 26, 155, 0.08);
+}
+
+.quest-processing-editor-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.quest-processing-editor-npcs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.quest-processing-npc-chip {
+  display: inline-block;
+  font-size: 0.72rem;
+  color: #7b1a9b;
+  background: rgba(123, 26, 155, 0.09);
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+  text-decoration: none;
+  transition: background 0.15s, color 0.15s;
+}
+
+.quest-processing-npc-chip:hover {
+  background: rgba(123, 26, 155, 0.2);
+  color: #5a1272;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .quest-processing-avatar,
+  .quest-view-script-btn,
+  .quest-processing-writer,
+  .quest-processing-writer::before,
+  .quest-processing-editors,
+  .quest-processing-editors::before,
+  .quest-processing-editor-card,
+  .quest-processing-npc-chip { transition: none; }
+  .quest-processing-avatar-link:hover .quest-processing-avatar,
+  .quest-view-script-btn:hover,
+  .quest-processing-writer:hover,
+  .quest-processing-editors:hover,
+  .quest-processing-editor-card:hover { transform: none; }
+  .quest-processing-writer::before,
+  .quest-processing-editors::before { transform: scaleX(1); }
+}
+
+@media (max-width: 520px) {
+  .quest-view-script-btn { margin-left: 0; }
+}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,8 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "80:80"
-      - "443:443"
+      - "8000:80"
+      - "8443:443"
     environment:
       - WEBSITE_DB_HOST=website
       - WEBSITE_DB_NAME=website
@@ -44,8 +44,8 @@ services:
       MYSQL_DATABASE: website
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "3306:3306"
+    expose:
+      - "3306"
     volumes:
       - website_data:/var/lib/mysql
     env_file:
@@ -58,8 +58,8 @@ services:
       MYSQL_DATABASE: api
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "3307:3306"
+    expose:
+      - "3306"
     volumes:
       - api_data:/var/lib/mysql
     env_file:
@@ -78,7 +78,7 @@ services:
     ports:
       - "8090:8080"
     environment:
-      - SWAGGER_JSON_URL=http://localhost/api/swagger
+      - SWAGGER_JSON_URL=http://localhost:8000/api/swagger
     depends_on:
       - web
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.8"
 services:
   web:
     image: ${DOCKER_IMAGE:-kmaxi/vow-website:latest}
+    restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"
@@ -41,13 +42,14 @@ services:
 
   website:
     image: mariadb:10.5.24
+    restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       MYSQL_DATABASE: website
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "3306:3306"
+    expose:
+      - "3306"
     volumes:
       - website_data:/var/lib/mysql
     env_file:
@@ -57,13 +59,14 @@ services:
 
   api:
     image: mariadb:10.5.24
+    restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       MYSQL_DATABASE: api
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "3307:3306"
+    expose:
+      - "3306"
     volumes:
       - api_data:/var/lib/mysql
     env_file:
@@ -73,6 +76,7 @@ services:
 
   adminer:
     image: adminer
+    restart: unless-stopped
     # Remove the public port binding as we'll access it through the web service
     # ports:
     #   - "8080:8080"

--- a/routes.ini
+++ b/routes.ini
@@ -97,7 +97,7 @@ scripts=
 /administration/npcs/manage/<0>/recast/<1>=Website\Administration\Administration?npc?<0>?false?recast?<1>
 /administration/npcs/manage/<0>/archive=Website\Administration\Administration?npc?<0>?false?archive
 /administration/npcs/manage/<0>/archive-quest-recordings/<1>=Website\Administration\Administration?npc?<0>?false?archive-quest-recordings?<1>
-/administration/scripts=Website\Administration\Scripts
+/administration/scripts=Website\Administration\Administration?scripts
 /logout=Website\Account\Logout
 
 ; API routes

--- a/routes.ini
+++ b/routes.ini
@@ -56,6 +56,7 @@ valid=
 search=
 discord-integration=
 swagger=
+scripts=
 
 ; Website routes
 [Routes]
@@ -96,6 +97,7 @@ swagger=
 /administration/npcs/manage/<0>/recast/<1>=Website\Administration\Administration?npc?<0>?false?recast?<1>
 /administration/npcs/manage/<0>/archive=Website\Administration\Administration?npc?<0>?false?archive
 /administration/npcs/manage/<0>/archive-quest-recordings/<1>=Website\Administration\Administration?npc?<0>?false?archive-quest-recordings?<1>
+/administration/scripts=Website\Administration\Scripts
 /logout=Website\Account\Logout
 
 ; API routes


### PR DESCRIPTION
In content page npc cards:
<img width="1337" height="843" alt="image" src="https://github.com/user-attachments/assets/8be11daf-9ca4-4743-8828-eae9fbc6513b" />


Bottom of content page
<img width="1771" height="964" alt="image" src="https://github.com/user-attachments/assets/9615d218-f951-4c4c-ab97-6e25fc061b4a" />

Look in npc page: 
<img width="1695" height="924" alt="image" src="https://github.com/user-attachments/assets/e32c4494-883d-46c1-9d61-5ee5ce7c7c58" />

Admin page:
<img width="1702" height="1016" alt="image" src="https://github.com/user-attachments/assets/80578387-84bd-4bdc-947f-366cb11858fa" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Script Credits administration page to manage script authors and sound editors across quests.
  * Quest pages now display script author and sound editor information with avatars and links.
  * Added script file viewing capability on quest pages.
  * NPC pages now show sound editor attribution.

* **Style**
  * Enhanced visual presentation of quest credits with improved card layouts, avatars, and interactive hover effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->