### PR TITLE
feat(docker): implement auto-restart for services and update port configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ this will create all the containers (databases and everything) for you.
 
 Once the containers are running, you can access the following services:
 
-- **Website:** [http://localhost](http://localhost) or [http://127.0.0.1](http://127.0.0.1)  
+- **Website:** [http://localhost:8000](http://localhost:8000) or [http://127.0.0.1:8000](http://127.0.0.1:8000)  
   The main Voices of Wynn website will be available here.
 
 - **phpMyAdmin:** [http://localhost:8080](http://localhost:8080)  

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -6,8 +6,8 @@ services:
       context: .
       dockerfile: Dockerfile
     ports:
-      - "80:80"
-      - "443:443"
+      - "8000:80"
+      - "8443:443"
     environment:
       - WEBSITE_DB_HOST=website
       - WEBSITE_DB_NAME=website
@@ -44,8 +44,8 @@ services:
       MYSQL_DATABASE: website
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "3306:3306"
+    expose:
+      - "3306"
     volumes:
       - website_data:/var/lib/mysql
     env_file:
@@ -58,8 +58,8 @@ services:
       MYSQL_DATABASE: api
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "3307:3306"
+    expose:
+      - "3306"
     volumes:
       - api_data:/var/lib/mysql
     env_file:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -78,7 +78,7 @@ services:
     ports:
       - "8090:8080"
     environment:
-      - SWAGGER_JSON_URL=http://localhost/api/swagger
+      - SWAGGER_JSON_URL=http://localhost:8000/api/swagger
     depends_on:
       - web
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.8"
 services:
   web:
     image: ${DOCKER_IMAGE:-kmaxi/vow-website:latest}
+    restart: unless-stopped
     ports:
       - "80:80"
       - "443:443"
@@ -41,13 +42,14 @@ services:
 
   website:
     image: mariadb:10.5.24
+    restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       MYSQL_DATABASE: website
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "3306:3306"
+    expose:
+      - "3306"
     volumes:
       - website_data:/var/lib/mysql
     env_file:
@@ -57,13 +59,14 @@ services:
 
   api:
     image: mariadb:10.5.24
+    restart: unless-stopped
     environment:
       MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
       MYSQL_DATABASE: api
       MYSQL_USER: ${DB_USER}
       MYSQL_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "3307:3306"
+    expose:
+      - "3306"
     volumes:
       - api_data:/var/lib/mysql
     env_file:
@@ -73,6 +76,7 @@ services:
 
   adminer:
     image: adminer
+    restart: unless-stopped
     # Remove the public port binding as we'll access it through the web service
     # ports:
     #   - "8080:8080"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated web service port configuration to 8000 (HTTP) and 8443 (HTTPS)
  * Restricted database service accessibility to internal Docker network only
  * Implemented automatic restart policy for core services to enhance reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->