### PR TITLE
feat(admin): add upload recording section to npc/manage page

### DIFF
--- a/Controllers/Website/Npc.php
+++ b/Controllers/Website/Npc.php
@@ -164,17 +164,23 @@ class Npc extends WebpageController
 	private function post(array $args): int
 	{
 		if ($this->disallowAdministration) {
-			return 403;
+			header('Content-Type: application/json');
+			http_response_code(403);
+			echo json_encode(['errors' => [['code' => 403, 'msg' => 'Forbidden', 'desc' => 'You do not have permission to upload recordings', 'file' => '']], 'successes' => []]);
+			exit();
 		}
 
 		if (empty($this->npc->getId())) {
-			return 400;
+			header('Content-Type: application/json');
+			http_response_code(400);
+			echo json_encode(['errors' => [['code' => 400, 'msg' => 'Bad Request', 'desc' => 'NPC ID is missing or invalid', 'file' => '']], 'successes' => []]);
+			exit();
 		}
 
 		if (empty($_FILES['recordings'])) {
 			header('Content-Type: application/json');
 			http_response_code(400);
-			echo json_encode(['errors' => [['desc' => 'No files uploaded']], 'successes' => []]);
+			echo json_encode(['errors' => [['code' => 400, 'msg' => 'Bad Request', 'desc' => 'No files uploaded', 'file' => '']], 'successes' => []]);
 			exit();
 		}
 

--- a/Controllers/Website/Npc.php
+++ b/Controllers/Website/Npc.php
@@ -157,6 +157,39 @@ class Npc extends WebpageController
 	}
 	
 	/**
+	 * Processing method for POST requests to this controller (recording files are being uploaded via AJAX)
+	 * @param array $args
+	 * @return int
+	 */
+	private function post(array $args): int
+	{
+		if ($this->disallowAdministration) {
+			return 403;
+		}
+
+		if (empty($this->npc->getId())) {
+			return 400;
+		}
+
+		if (empty($_FILES['recordings'])) {
+			header('Content-Type: application/json');
+			http_response_code(400);
+			echo json_encode(['errors' => [['desc' => 'No files uploaded']], 'successes' => []]);
+			exit();
+		}
+
+		$uploader = new RecordingUploader();
+		$uploader->upload($_FILES['recordings'], false, null, $this->npc->getId());
+
+		header('Content-Type: application/json');
+		echo json_encode([
+			'errors' => $uploader->getErrors(),
+			'successes' => $uploader->getSuccesses()
+		]);
+		exit();
+	}
+
+	/**
 	 * Processing method for DELETE requests to this controller (a recording is supposed to be deleted)
 	 * @param array $args Recording ID as the first element
 	 * @return int|bool

--- a/Controllers/Website/Npc.php
+++ b/Controllers/Website/Npc.php
@@ -14,6 +14,15 @@ class Npc extends WebpageController
 {
 	private NpcModel $npc;
 	private bool $disallowAdministration;
+    private ?string $jsonResponse = null;
+
+    public function displayView(): string
+    {
+        if ($this->jsonResponse !== null) {
+            return $this->jsonResponse;
+        }
+        return parent::displayView();
+    }
 	
 	/**
 	 * @inheritDoc
@@ -164,35 +173,26 @@ class Npc extends WebpageController
 	private function post(array $args): int
 	{
 		if ($this->disallowAdministration) {
-			header('Content-Type: application/json');
-			http_response_code(403);
-			echo json_encode(['errors' => [['code' => 403, 'msg' => 'Forbidden', 'desc' => 'You do not have permission to upload recordings', 'file' => '']], 'successes' => []]);
-			exit();
+			return 403;
 		}
 
 		if (empty($this->npc->getId())) {
-			header('Content-Type: application/json');
-			http_response_code(400);
-			echo json_encode(['errors' => [['code' => 400, 'msg' => 'Bad Request', 'desc' => 'NPC ID is missing or invalid', 'file' => '']], 'successes' => []]);
-			exit();
+			return 400;
 		}
 
 		if (empty($_FILES['recordings'])) {
-			header('Content-Type: application/json');
-			http_response_code(400);
-			echo json_encode(['errors' => [['code' => 400, 'msg' => 'Bad Request', 'desc' => 'No files uploaded', 'file' => '']], 'successes' => []]);
-			exit();
+			return 400;
 		}
 
 		$uploader = new RecordingUploader();
 		$uploader->upload($_FILES['recordings'], false, null, $this->npc->getId());
 
 		header('Content-Type: application/json');
-		echo json_encode([
+		$this->jsonResponse = json_encode([
 			'errors' => $uploader->getErrors(),
 			'successes' => $uploader->getSuccesses()
 		]);
-		exit();
+		return 200;
 	}
 
 	/**
@@ -227,7 +227,7 @@ class Npc extends WebpageController
 			//Delete file
 			Storage::get()->delete('recordings/'.$filename);
 		}
-		exit($result);
+		return ($result) ? 204 : 500;
 	}
 }
 

--- a/Views/npc.phtml
+++ b/Views/npc.phtml
@@ -51,6 +51,27 @@
     <?php endif ?>
 </section>
 
+<?php if (${basename(__FILE__, '.phtml') . '_admin'}) : ?>
+<!-- Upload Drop Zone -->
+<section class="upload-drop-zone-card npc-animate-on-scroll">
+    <div id="upload-drop-zone" class="upload-drop-zone">
+        <p class="upload-drop-text">Drop recording files here</p>
+        <p class="upload-drop-subtext">or click to browse (.ogg files)</p>
+        <input type="file" id="upload-file-input" accept="audio/ogg" multiple hidden />
+    </div>
+    <details class="upload-info">
+        <summary>How does this work?</summary>
+        <ul>
+            <li>Files must be named <code>questname-npcname-linenumber.ogg</code> (all lowercase, no spaces).</li>
+            <li>The <strong>NPC name</strong> in the filename is ignored &mdash; recordings are always assigned to this NPC.</li>
+            <li>The <strong>quest name</strong> is matched from the filename &mdash; use the quest name in all lowercase with no spaces (e.g. "A Grave Mistake" becomes <code>agravemistake</code>).</li>
+            <li>If a file with the same name already exists on the server, the new file will be <strong>automatically renamed</strong> (e.g. <code>_(1)</code>, <code>_(2)</code>) to avoid conflicts.</li>
+        </ul>
+    </details>
+    <div id="upload-status" class="upload-status" style="display:none;"></div>
+</section>
+<?php endif ?>
+
 <!-- NPC Card (expanded) -->
 <?php
 $prefix = basename(__FILE__, '.phtml') . '_';

--- a/Views/npc.phtml
+++ b/Views/npc.phtml
@@ -54,7 +54,7 @@
 <?php if (${basename(__FILE__, '.phtml') . '_admin'}) : ?>
 <!-- Upload Drop Zone -->
 <section class="upload-drop-zone-card npc-animate-on-scroll">
-    <div id="upload-drop-zone" class="upload-drop-zone">
+    <div id="upload-drop-zone" class="upload-drop-zone" role="button" tabindex="0" aria-label="Drop recording files here or click to browse">
         <p class="upload-drop-text">Drop recording files here</p>
         <p class="upload-drop-subtext">or click to browse (.ogg files)</p>
         <input type="file" id="upload-file-input" accept="audio/ogg" multiple hidden />

--- a/css/npc.css
+++ b/css/npc.css
@@ -317,6 +317,11 @@
   background: rgba(123, 26, 155, 0.05);
 }
 
+.upload-drop-zone:focus-visible {
+  outline: 2px solid var(--npc-gradient-purple);
+  outline-offset: 2px;
+}
+
 .upload-drop-zone.uploading {
   opacity: 0.6;
   pointer-events: none;
@@ -500,7 +505,8 @@
   #change-actor-btn,
   #archive-btn,
   #va-confirm-change,
-  .back-btn-container .backbtn {
+  .back-btn-container .backbtn,
+  .upload-drop-zone {
     transition: none;
   }
 }

--- a/css/npc.css
+++ b/css/npc.css
@@ -293,6 +293,97 @@
   outline-offset: 2px;
 }
 
+/* Upload Drop Zone */
+.upload-drop-zone-card {
+  background: var(--npc-card-bg);
+  border-radius: var(--npc-card-border-radius);
+  padding: var(--npc-space-lg);
+  box-shadow: var(--npc-card-shadow);
+  margin-bottom: var(--npc-space-lg);
+  text-align: center;
+}
+
+.upload-drop-zone {
+  border: 2px dashed #ccc;
+  border-radius: 0.75rem;
+  padding: var(--npc-space-xl) var(--npc-space-lg);
+  cursor: pointer;
+  transition: border-color var(--npc-transition-fast) ease, background var(--npc-transition-fast) ease;
+}
+
+.upload-drop-zone:hover,
+.upload-drop-zone.drag-over {
+  border-color: var(--npc-gradient-purple);
+  background: rgba(123, 26, 155, 0.05);
+}
+
+.upload-drop-zone.uploading {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.upload-drop-text {
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: #666;
+  margin: 0 0 0.25rem;
+}
+
+.upload-drop-subtext {
+  font-size: 0.9rem;
+  color: #999;
+  margin: 0;
+}
+
+.upload-info {
+  margin-top: var(--npc-space-sm);
+  text-align: left;
+  font-size: 0.9rem;
+  color: #555;
+}
+
+.upload-info summary {
+  cursor: pointer;
+  color: var(--npc-gradient-purple);
+  font-weight: bold;
+}
+
+.upload-info ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.upload-info li {
+  margin-bottom: 0.35rem;
+}
+
+.upload-info code {
+  background: #f0f0f0;
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.25rem;
+  font-size: 0.85em;
+}
+
+.upload-status {
+  margin-top: var(--npc-space-sm);
+  text-align: left;
+}
+
+.upload-progress {
+  color: var(--npc-gradient-purple);
+  font-weight: bold;
+}
+
+.upload-result-success p {
+  color: #2e7d32;
+  margin: 0.25rem 0;
+}
+
+.upload-result-error p {
+  color: #c62828;
+  margin: 0.25rem 0;
+}
+
 /* Back Button */
 .back-btn-container {
   text-align: center;

--- a/js/npc.js
+++ b/js/npc.js
@@ -100,7 +100,7 @@ $("#archive-btn").on('click', function() {
     }
 
     $.ajax({
-        url: "/administration/npcs/manage/" + npcId + "/archive",
+        url: "administration/npcs/manage/" + npcId + "/archive",
         type: 'PUT',
         success: function(result, message) { /* Shouldn't happen */ },
         error: function(result, message, error) {
@@ -150,21 +150,39 @@ var $fileInput = document.getElementById('upload-file-input');
 var $uploadStatus = document.getElementById('upload-status');
 
 if ($dropZone) {
+    var dragCounter = 0;
+
     $dropZone.addEventListener('click', function() {
         $fileInput.click();
     });
 
+    $dropZone.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' || e.key === ' ' || e.key === 'Spacebar') {
+            e.preventDefault();
+            $fileInput.click();
+        }
+    });
+
     $dropZone.addEventListener('dragover', function(e) {
         e.preventDefault();
+    });
+
+    $dropZone.addEventListener('dragenter', function(e) {
+        e.preventDefault();
+        dragCounter++;
         $dropZone.classList.add('drag-over');
     });
 
     $dropZone.addEventListener('dragleave', function() {
-        $dropZone.classList.remove('drag-over');
+        dragCounter--;
+        if (dragCounter === 0) {
+            $dropZone.classList.remove('drag-over');
+        }
     });
 
     $dropZone.addEventListener('drop', function(e) {
         e.preventDefault();
+        dragCounter = 0;
         $dropZone.classList.remove('drag-over');
         if (e.dataTransfer.files.length > 0) {
             uploadRecordings(e.dataTransfer.files);
@@ -190,32 +208,49 @@ function uploadRecordings(files) {
     }
 
     $.ajax({
-        url: '/administration/npcs/manage/' + npcId,
+        url: 'administration/npcs/manage/' + npcId,
         type: 'POST',
         data: fd,
         processData: false,
         contentType: false,
         success: function(result) {
-            var html = '';
+            $uploadStatus.textContent = '';
             if (result.successes && result.successes.length > 0) {
-                html += '<div class="upload-result-success">';
+                var successDiv = document.createElement('div');
+                successDiv.className = 'upload-result-success';
                 result.successes.forEach(function(s) {
-                    html += '<p>' + s.desc + ' — <strong>' + s.file + '</strong></p>';
+                    var p = document.createElement('p');
+                    p.textContent = s.desc + ' — ';
+                    var strong = document.createElement('strong');
+                    strong.textContent = s.file;
+                    p.appendChild(strong);
+                    successDiv.appendChild(p);
                 });
-                html += '</div>';
+                $uploadStatus.appendChild(successDiv);
             }
             if (result.errors && result.errors.length > 0) {
-                html += '<div class="upload-result-error">';
+                var errorDiv = document.createElement('div');
+                errorDiv.className = 'upload-result-error';
                 result.errors.forEach(function(e) {
-                    html += '<p>' + e.desc + ' — <strong>' + e.file + '</strong></p>';
+                    var p = document.createElement('p');
+                    p.textContent = e.desc + ' — ';
+                    var strong = document.createElement('strong');
+                    strong.textContent = e.file;
+                    p.appendChild(strong);
+                    errorDiv.appendChild(p);
                 });
-                html += '</div>';
+                $uploadStatus.appendChild(errorDiv);
             }
-            $uploadStatus.innerHTML = html;
             $dropZone.classList.remove('uploading');
         },
         error: function(result, message, error) {
-            $uploadStatus.innerHTML = '<div class="upload-result-error"><p>Upload failed: ' + error + '</p></div>';
+            $uploadStatus.textContent = '';
+            var errorDiv = document.createElement('div');
+            errorDiv.className = 'upload-result-error';
+            var p = document.createElement('p');
+            p.textContent = 'Upload failed: ' + error;
+            errorDiv.appendChild(p);
+            $uploadStatus.appendChild(errorDiv);
             $dropZone.classList.remove('uploading');
         }
     });

--- a/js/npc.js
+++ b/js/npc.js
@@ -141,6 +141,90 @@ $(".delete-recording-btn").on('click', function(event){
     });
 });
 
+// ==========================================================================
+// RECORDING UPLOAD DROP ZONE
+// ==========================================================================
+
+var $dropZone = document.getElementById('upload-drop-zone');
+var $fileInput = document.getElementById('upload-file-input');
+var $uploadStatus = document.getElementById('upload-status');
+
+if ($dropZone) {
+    $dropZone.addEventListener('click', function() {
+        $fileInput.click();
+    });
+
+    $dropZone.addEventListener('dragover', function(e) {
+        e.preventDefault();
+        $dropZone.classList.add('drag-over');
+    });
+
+    $dropZone.addEventListener('dragleave', function() {
+        $dropZone.classList.remove('drag-over');
+    });
+
+    $dropZone.addEventListener('drop', function(e) {
+        e.preventDefault();
+        $dropZone.classList.remove('drag-over');
+        if (e.dataTransfer.files.length > 0) {
+            uploadRecordings(e.dataTransfer.files);
+        }
+    });
+
+    $fileInput.addEventListener('change', function() {
+        if ($fileInput.files.length > 0) {
+            uploadRecordings($fileInput.files);
+            $fileInput.value = '';
+        }
+    });
+}
+
+function uploadRecordings(files) {
+    $dropZone.classList.add('uploading');
+    $uploadStatus.style.display = 'block';
+    $uploadStatus.innerHTML = '<p class="upload-progress">Uploading ' + files.length + ' file(s)...</p>';
+
+    var fd = new FormData();
+    for (var i = 0; i < files.length; i++) {
+        fd.append('recordings[]', files[i]);
+    }
+
+    $.ajax({
+        url: '/administration/npcs/manage/' + npcId,
+        type: 'POST',
+        data: fd,
+        processData: false,
+        contentType: false,
+        success: function(result) {
+            var html = '';
+            if (result.successes && result.successes.length > 0) {
+                html += '<div class="upload-result-success">';
+                result.successes.forEach(function(s) {
+                    html += '<p>' + s.desc + ' — <strong>' + s.file + '</strong></p>';
+                });
+                html += '</div>';
+            }
+            if (result.errors && result.errors.length > 0) {
+                html += '<div class="upload-result-error">';
+                result.errors.forEach(function(e) {
+                    html += '<p>' + e.desc + ' — <strong>' + e.file + '</strong></p>';
+                });
+                html += '</div>';
+            }
+            $uploadStatus.innerHTML = html;
+            $dropZone.classList.remove('uploading');
+        },
+        error: function(result, message, error) {
+            $uploadStatus.innerHTML = '<div class="upload-result-error"><p>Upload failed: ' + error + '</p></div>';
+            $dropZone.classList.remove('uploading');
+        }
+    });
+}
+
+// ==========================================================================
+// ARCHIVING QUEST RECORDINGS SECTION
+// ==========================================================================
+
 var $archivingRecordings;
 
 $(".archive-all-recordings-btn").on('click', function(event) {

--- a/js/npc.js
+++ b/js/npc.js
@@ -66,7 +66,7 @@ $("#voice-actor-form").on('submit', function(event) {
     voiceActorName = $(event.target).find('select option:selected').text();
     voiceActorAvatar = $(event.target).find('select option:selected').attr('data-avatar-link');
     $.ajax({
-        url: "administration/npcs/manage/" + npcId + "/recast/" + voiceActorId,
+        url: "/administration/npcs/manage/" + npcId + "/recast/" + voiceActorId,
         type: 'PUT',
         success: function(result, message) {
             $(".voice-actor-avatar").attr('src', voiceActorAvatar);
@@ -100,7 +100,7 @@ $("#archive-btn").on('click', function() {
     }
 
     $.ajax({
-        url: "administration/npcs/manage/" + npcId + "/archive",
+        url: "/administration/npcs/manage/" + npcId + "/archive",
         type: 'PUT',
         success: function(result, message) { /* Shouldn't happen */ },
         error: function(result, message, error) {
@@ -129,7 +129,7 @@ $(".delete-recording-btn").on('click', function(event){
     }
     $deletingRecording = $(event.target).closest(".recording-row");
     $.ajax({
-        url: "administration/npcs/manage/" + npcId + "/delete/" + $(event.target).attr("data-recording-id"),
+        url: "/administration/npcs/manage/" + npcId + "/delete/" + $(event.target).attr("data-recording-id"),
         type: 'DELETE',
         success: function(result, message) {
             $deletingRecording.remove();
@@ -208,7 +208,7 @@ function uploadRecordings(files) {
     }
 
     $.ajax({
-        url: 'administration/npcs/manage/' + npcId,
+        url: '/administration/npcs/manage/' + npcId,
         type: 'POST',
         data: fd,
         processData: false,
@@ -276,7 +276,7 @@ $(".archive-all-recordings-btn").on('click', function(event) {
     let questId = $(event.target).attr('data-quest-id');
     $archivingRecordings = $(event.target).closest('.quest-card').find('.recording-row');
     $.ajax({
-        url: "administration/npcs/manage/" + npcId + "/archive-quest-recordings/" + questId,
+        url: "/administration/npcs/manage/" + npcId + "/archive-quest-recordings/" + questId,
         type: 'PUT',
         success: function(result, message) {
             $archivingRecordings.remove();

--- a/js/npc.js
+++ b/js/npc.js
@@ -211,8 +211,8 @@ function uploadRecordings(files) {
         url: '/administration/npcs/manage/' + npcId,
         type: 'POST',
         data: fd,
-        processData: false,
-        contentType: false,
+        processData: false, // prevent jQuery from serializing FormData into a query string
+        contentType: false, // let the browser set multipart/form-data with the correct boundary automatically
         success: function(result) {
             $uploadStatus.textContent = '';
             if (result.successes && result.successes.length > 0) {

--- a/js/npcs.js
+++ b/js/npcs.js
@@ -14,7 +14,7 @@ $(".rearrange-up-btn").click(function(event) {
     let npc2Id = $moveDownRow.attr('data-npc-id');
 
     $.ajax({
-        url: "administration/npcs/swap/" + questId + "/" + npc1Id + "/" + npc2Id,
+        url: "/administration/npcs/swap/" + questId + "/" + npc1Id + "/" + npc2Id,
         type: 'PUT',
         success: function(result, message, error) {
             $moveDownRow.insertAfter($moveUpRow);
@@ -38,7 +38,7 @@ $(".rearrange-down-btn").click(function(event) {
     let npc2Id = $moveDownRow.attr('data-npc-id');
 
     $.ajax({
-        url: "administration/npcs/swap/" + questId + "/" + npc1Id + "/" + npc2Id,
+        url: "/administration/npcs/swap/" + questId + "/" + npc1Id + "/" + npc2Id,
         type: 'PUT',
         success: function(result, message, error) {
             $moveDownRow.insertAfter($moveUpRow);


### PR DESCRIPTION
The mass upload recording feature is really hard to use for individual files. Figuring out the ids to upload to one idrectly is challenging. This simplifies the process for TrekkieCow a lot.

Related to #186 

<img width="1269" height="836" alt="Screenshot 2026-04-24 at 22 12 41" src="https://github.com/user-attachments/assets/16702cd4-7f5b-4f32-8bc7-66c0f2ff32c7" />
<img width="1213" height="808" alt="Screenshot 2026-04-24 at 22 12 57" src="https://github.com/user-attachments/assets/e17135be-0633-4770-927c-4e82dbb4153c" />
<img width="1155" height="795" alt="Screenshot 2026-04-24 at 22 13 36" src="https://github.com/user-attachments/assets/e7900ead-b9bc-4d5f-bfb6-774ae42b03ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin-only recording upload interface with drag-and-drop functionality for NPC management
  * Upload progress tracking with real-time feedback on success and error results
  * Support for multiple audio file uploads in a single operation
  * Help documentation detailing filename format expectations and conflict resolution behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->