### PR TITLE
feat(admin): add archieve npc button

### DIFF
--- a/app-frontend/src/api/content.ts
+++ b/app-frontend/src/api/content.ts
@@ -1,5 +1,7 @@
 import { apiFetch } from './client'
 import type {
+  ArchiveNpcRequest,
+  ArchiveNpcResponse,
   ContentOptionsResponse,
   ContentSearchRequest,
   ContentSearchResponse,
@@ -84,6 +86,16 @@ export function updateNpcVoiceActor(
 ): Promise<void> {
   return apiFetch<void>(`/admin/content/npcs/${npcId}/voice-actor`, {
     method: 'PATCH',
+    body: request,
+  })
+}
+
+export function archiveNpc(
+  npcId: number,
+  request: ArchiveNpcRequest,
+): Promise<ArchiveNpcResponse> {
+  return apiFetch<ArchiveNpcResponse>(`/admin/content/npcs/${npcId}/archive`, {
+    method: 'POST',
     body: request,
   })
 }

--- a/app-frontend/src/api/types.ts
+++ b/app-frontend/src/api/types.ts
@@ -154,6 +154,14 @@ export interface CreateContentResponse {
   id: number
 }
 
+export interface ArchiveNpcRequest {
+  createReplacement: boolean
+}
+
+export interface ArchiveNpcResponse {
+  replacementNpcId: number | null
+}
+
 export interface UpdateContentNameRequest {
   name: string
 }

--- a/app-frontend/src/features/content/components/ContentManageDialog.vue
+++ b/app-frontend/src/features/content/components/ContentManageDialog.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, useTemplateRef, watch } from 'vue'
 import {
+  Archive,
+  ArchiveRestore,
   Edit,
   FileUp,
   Headphones,
@@ -34,6 +36,7 @@ import type { ContentOption, ContentSearchNpc, ContentSearchQuest } from '@/api/
 import type { UploadNpcRecordingResult } from '@/api/types'
 import { CONTENT_NONE, messageFromContentError, optionalContentId } from '../contentUtils'
 import {
+  useArchiveNpc,
   useDeleteNpcRecording,
   useDeleteQuest,
   useLinkQuestNpc,
@@ -69,6 +72,7 @@ const props = defineProps<{
 }>()
 
 const emit = defineEmits<{
+  npcArchived: [replacementNpcId: number | null]
   'update:open': [value: boolean]
 }>()
 
@@ -77,6 +81,7 @@ const updateQuestWriterMutation = useUpdateQuestWriter()
 const deleteQuestMutation = useDeleteQuest()
 const updateNpcMutation = useUpdateNpc()
 const updateNpcVoiceActorMutation = useUpdateNpcVoiceActor()
+const archiveNpcMutation = useArchiveNpc()
 const updateQuestNpcSoundEditorMutation = useUpdateQuestNpcSoundEditor()
 const linkQuestNpcMutation = useLinkQuestNpc()
 const unlinkQuestNpcMutation = useUnlinkQuestNpc()
@@ -102,6 +107,7 @@ const recordingOverwrite = ref(false)
 const recordingResults = ref<UploadNpcRecordingResult[]>([])
 const isDraggingRecordings = ref(false)
 const deletingRecordingId = ref<number | null>(null)
+const archivingMode = ref<'replace' | 'archive-only' | null>(null)
 
 const selectedQuestId = computed(() => props.selectedQuest?.questId ?? null)
 const selectedNpcId = computed(() => props.selectedNpc?.npcId ?? null)
@@ -174,6 +180,7 @@ watch(
     if (recordingsInput.value) recordingsInput.value.value = ''
     pendingImageFile.value = null
     cropDialogOpen.value = false
+    archivingMode.value = null
     if (imageInput.value) imageInput.value.value = ''
 
     if (props.mode === 'quest' && props.selectedQuest) {
@@ -391,6 +398,28 @@ async function unlinkNpc() {
     })
     setOpen(false)
   }, 'NPC unlinked from quest.')
+}
+
+async function archiveNpc(createReplacement: boolean) {
+  if (!props.selectedNpc) return
+
+  const message = createReplacement
+    ? 'Archive this NPC and create a replacement with the same name and picture?\n\nThe original NPC will be removed from current quest content, its recordings will be renamed as archived, and the replacement will have no voice actor or recordings.'
+    : 'Archive this NPC without creating a replacement?\n\nThe NPC will be removed from all current quest content and its recordings will be renamed as archived. This cannot be undone from this page.'
+  if (!window.confirm(message)) return
+
+  archivingMode.value = createReplacement ? 'replace' : 'archive-only'
+  await runDialogAction(async () => {
+    const response = await archiveNpcMutation.mutateAsync({
+      npcId: props.selectedNpc!.npcId,
+      request: { createReplacement },
+    })
+    emit('npcArchived', response.replacementNpcId)
+    if (response.replacementNpcId === null) {
+      setOpen(false)
+    }
+  }, createReplacement ? 'NPC archived and replacement created.' : 'NPC archived.')
+  archivingMode.value = null
 }
 </script>
 
@@ -856,6 +885,43 @@ async function unlinkNpc() {
               <Unlink class="size-4" />
               Unlink NPC
             </Button>
+          </div>
+
+          <div class="space-y-3 border-t pt-4">
+            <div>
+              <p class="text-sm font-medium">Archive NPC</p>
+              <p class="text-xs text-muted-foreground">
+                Archiving removes this NPC from current content and marks its recordings as outdated.
+              </p>
+            </div>
+            <div class="flex flex-col gap-2 sm:flex-row sm:justify-end">
+              <Button
+                variant="outline"
+                class="gap-2 self-start sm:self-auto"
+                :disabled="archiveNpcMutation.isPending.value"
+                @click="archiveNpc(true)"
+              >
+                <Loader2
+                  v-if="archivingMode === 'replace'"
+                  class="size-4 animate-spin"
+                />
+                <ArchiveRestore v-else class="size-4" />
+                Archive and recreate
+              </Button>
+              <Button
+                variant="destructive"
+                class="gap-2 self-start sm:self-auto"
+                :disabled="archiveNpcMutation.isPending.value"
+                @click="archiveNpc(false)"
+              >
+                <Loader2
+                  v-if="archivingMode === 'archive-only'"
+                  class="size-4 animate-spin"
+                />
+                <Archive v-else class="size-4" />
+                Archive only
+              </Button>
+            </div>
           </div>
         </div>
       </DialogContent>

--- a/app-frontend/src/features/content/queries.ts
+++ b/app-frontend/src/features/content/queries.ts
@@ -1,6 +1,7 @@
 import { computed, type ComputedRef, type Ref } from 'vue'
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/vue-query'
 import {
+  archiveNpc,
   createNpc,
   createQuest,
   deleteNpcRecording,
@@ -21,6 +22,7 @@ import {
   uploadQuestScript,
 } from '@/api/content'
 import type {
+  ArchiveNpcRequest,
   ContentSearchRequest,
   CreateNpcRequest,
   CreateQuestRequest,
@@ -116,6 +118,15 @@ export function useUpdateNpcVoiceActor() {
   return useMutation({
     mutationFn: ({ npcId, request }: { npcId: number; request: UpdateNpcVoiceActorRequest }) =>
       updateNpcVoiceActor(npcId, request),
+    onSuccess: () => invalidateContent(queryClient),
+  })
+}
+
+export function useArchiveNpc() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ npcId, request }: { npcId: number; request: ArchiveNpcRequest }) =>
+      archiveNpc(npcId, request),
     onSuccess: () => invalidateContent(queryClient),
   })
 }

--- a/app-frontend/src/features/content/views/ContentManageView.vue
+++ b/app-frontend/src/features/content/views/ContentManageView.vue
@@ -48,6 +48,7 @@ const dialogOpen = ref(false)
 const dialogMode = ref<DialogMode>(null)
 const selectedQuest = ref<ContentSearchQuest | null>(null)
 const selectedNpc = ref<ContentSearchNpc | null>(null)
+const pendingReplacementNpcId = ref<number | null>(null)
 
 const { data: options, isLoading, isError, error } = useContentOptions()
 
@@ -78,6 +79,7 @@ const {
   isFetching: searchFetching,
   isError: searchIsError,
   error: searchError,
+  refetch: refetchContentSearch,
 } = useContentSearch(searchParams)
 
 const searchResults = computed(() => searchData.value?.results ?? [])
@@ -137,6 +139,44 @@ function openNpcDialog(quest: ContentSearchQuest, npc: ContentSearchNpc) {
   dialogMode.value = 'npc'
   dialogOpen.value = true
 }
+
+function findNpcInSearchResults(npcId: number) {
+  for (const quest of searchResults.value) {
+    const npc = quest.npcs.find((candidate) => candidate.npcId === npcId)
+    if (npc) return { quest, npc }
+  }
+
+  return null
+}
+
+function openReplacementNpcIfAvailable(npcId: number) {
+  const match = findNpcInSearchResults(npcId)
+  if (!match) return false
+
+  openNpcDialog(match.quest, match.npc)
+  pendingReplacementNpcId.value = null
+  return true
+}
+
+async function onNpcArchived(replacementNpcId: number | null) {
+  if (replacementNpcId === null) {
+    selectedQuest.value = null
+    selectedNpc.value = null
+    dialogMode.value = null
+    return
+  }
+
+  pendingReplacementNpcId.value = replacementNpcId
+  dialogOpen.value = false
+  await refetchContentSearch()
+  openReplacementNpcIfAvailable(replacementNpcId)
+}
+
+watch(searchResults, () => {
+  if (pendingReplacementNpcId.value !== null) {
+    openReplacementNpcIfAvailable(pendingReplacementNpcId.value)
+  }
+})
 </script>
 
 <template>
@@ -238,6 +278,7 @@ function openNpcDialog(quest: ContentSearchQuest, npc: ContentSearchNpc) {
       :sound-editors="soundEditors"
       :voice-actors="voiceActors"
       :writers="writers"
+      @npc-archived="onNpcArchived"
     />
   </div>
 </template>

--- a/app-frontend/src/features/content/views/ContentManageView.vue
+++ b/app-frontend/src/features/content/views/ContentManageView.vue
@@ -49,6 +49,7 @@ const dialogMode = ref<DialogMode>(null)
 const selectedQuest = ref<ContentSearchQuest | null>(null)
 const selectedNpc = ref<ContentSearchNpc | null>(null)
 const pendingReplacementNpcId = ref<number | null>(null)
+let pendingReplacementTimeout: ReturnType<typeof setTimeout> | null = null
 
 const { data: options, isLoading, isError, error } = useContentOptions()
 
@@ -84,6 +85,23 @@ const {
 
 const searchResults = computed(() => searchData.value?.results ?? [])
 const total = computed(() => searchData.value?.total ?? 0)
+
+function clearPendingReplacementNpc() {
+  pendingReplacementNpcId.value = null
+  if (pendingReplacementTimeout !== null) {
+    clearTimeout(pendingReplacementTimeout)
+    pendingReplacementTimeout = null
+  }
+}
+
+function setPendingReplacementNpc(npcId: number) {
+  clearPendingReplacementNpc()
+  pendingReplacementNpcId.value = npcId
+  pendingReplacementTimeout = setTimeout(() => {
+    pendingReplacementNpcId.value = null
+    pendingReplacementTimeout = null
+  }, 3000)
+}
 
 watch(
   [activeTab, searchParams],
@@ -126,14 +144,21 @@ watch(
   },
 )
 
+watch([activeTab, searchQuest, searchNpc, page, pageSize], clearPendingReplacementNpc)
+
 function openQuestDialog(quest: ContentSearchQuest) {
+  clearPendingReplacementNpc()
   selectedQuest.value = quest
   selectedNpc.value = null
   dialogMode.value = 'quest'
   dialogOpen.value = true
 }
 
-function openNpcDialog(quest: ContentSearchQuest, npc: ContentSearchNpc) {
+function openNpcDialog(quest: ContentSearchQuest, npc: ContentSearchNpc, clearPending = true) {
+  if (clearPending) {
+    clearPendingReplacementNpc()
+  }
+
   selectedQuest.value = quest
   selectedNpc.value = npc
   dialogMode.value = 'npc'
@@ -153,8 +178,8 @@ function openReplacementNpcIfAvailable(npcId: number) {
   const match = findNpcInSearchResults(npcId)
   if (!match) return false
 
-  openNpcDialog(match.quest, match.npc)
-  pendingReplacementNpcId.value = null
+  openNpcDialog(match.quest, match.npc, false)
+  clearPendingReplacementNpc()
   return true
 }
 
@@ -166,7 +191,7 @@ async function onNpcArchived(replacementNpcId: number | null) {
     return
   }
 
-  pendingReplacementNpcId.value = replacementNpcId
+  setPendingReplacementNpc(replacementNpcId)
   dialogOpen.value = false
   await refetchContentSearch()
   openReplacementNpcIfAvailable(replacementNpcId)

--- a/vow-api/src/VoW.Api/Contracts/Content/ArchiveNpcRequest.cs
+++ b/vow-api/src/VoW.Api/Contracts/Content/ArchiveNpcRequest.cs
@@ -1,0 +1,3 @@
+namespace VoW.Api.Contracts.Content;
+
+public sealed record ArchiveNpcRequest(bool CreateReplacement);

--- a/vow-api/src/VoW.Api/Contracts/Content/ArchiveNpcResponse.cs
+++ b/vow-api/src/VoW.Api/Contracts/Content/ArchiveNpcResponse.cs
@@ -1,0 +1,3 @@
+namespace VoW.Api.Contracts.Content;
+
+public sealed record ArchiveNpcResponse(int? ReplacementNpcId);

--- a/vow-api/src/VoW.Api/Controllers/Admin/ContentController.cs
+++ b/vow-api/src/VoW.Api/Controllers/Admin/ContentController.cs
@@ -107,6 +107,21 @@ public sealed class ContentController(IContentService contentService) : Controll
         return result.Succeeded ? NoContent() : ProblemFrom(result);
     }
 
+    [HttpPost("npcs/{npcId:int}/archive")]
+    public async Task<IActionResult> ArchiveNpc(
+        int npcId,
+        [FromBody] ArchiveNpcRequest request,
+        CancellationToken cancellationToken)
+    {
+        var result = await contentService.ArchiveNpcAsync(npcId, request, cancellationToken);
+        if (!result.Succeeded)
+        {
+            return ProblemFrom(result);
+        }
+
+        return Ok(new ArchiveNpcResponse(result.Id));
+    }
+
     [HttpPost("quests/{questId:int}/npcs")]
     public async Task<IActionResult> LinkNpcToQuest(
         int questId,

--- a/vow-api/src/VoW.Api/Domain/Content/NpcArchiveData.cs
+++ b/vow-api/src/VoW.Api/Domain/Content/NpcArchiveData.cs
@@ -1,0 +1,10 @@
+namespace VoW.Api.Domain.Content;
+
+public sealed record NpcArchiveData(
+    int NpcId,
+    string Name,
+    string DegeneratedName,
+    bool Archived,
+    IReadOnlyCollection<RecordingFile> Recordings);
+
+public sealed record ArchivedRecordingFile(int RecordingId, string FileName);

--- a/vow-api/src/VoW.Api/Repositories/ContentRepository.cs
+++ b/vow-api/src/VoW.Api/Repositories/ContentRepository.cs
@@ -685,7 +685,7 @@ public sealed class ContentRepository(IConfiguration configuration) : IContentRe
                 transaction,
                 cancellationToken: cancellationToken);
             var npc = await connection.QuerySingleOrDefaultAsync<NpcArchiveRow>(npcCommand);
-            if (npc is null)
+            if (npc is null || npc.Archived)
             {
                 await transaction.RollbackAsync(cancellationToken);
                 return null;

--- a/vow-api/src/VoW.Api/Repositories/ContentRepository.cs
+++ b/vow-api/src/VoW.Api/Repositories/ContentRepository.cs
@@ -94,6 +94,39 @@ public sealed class ContentRepository(IConfiguration configuration) : IContentRe
         return await connection.ExecuteScalarAsync<int>(command) > 0;
     }
 
+    public async Task<NpcArchiveData?> GetNpcArchiveDataAsync(int npcId, CancellationToken cancellationToken)
+    {
+        const string npcSql = """
+            SELECT
+                npc_id AS NpcId,
+                name AS Name,
+                degenerated_name AS DegeneratedName,
+                archived AS Archived
+            FROM npc
+            WHERE npc_id = @NpcId
+            LIMIT 1;
+            """;
+
+        const string recordingsSql = """
+            SELECT recording_id AS RecordingId, file AS File
+            FROM recording
+            WHERE npc_id = @NpcId AND archived = 0
+            ORDER BY recording_id;
+            """;
+
+        await using var connection = new MySqlConnection(DatabaseSettings.GetWebsiteConnectionString(configuration));
+        var command = new CommandDefinition(npcSql, new { NpcId = npcId }, cancellationToken: cancellationToken);
+        var npc = await connection.QuerySingleOrDefaultAsync<NpcArchiveRow>(command);
+        if (npc is null)
+        {
+            return null;
+        }
+
+        command = new CommandDefinition(recordingsSql, new { NpcId = npcId }, cancellationToken: cancellationToken);
+        var recordings = (await connection.QueryAsync<RecordingFile>(command)).AsList();
+        return new NpcArchiveData(npc.NpcId, npc.Name, npc.DegeneratedName, npc.Archived, recordings);
+    }
+
     public async Task<string?> GetQuestDegeneratedNameAsync(int questId, CancellationToken cancellationToken)
     {
         const string sql = "SELECT degenerated_name FROM quest WHERE quest_id = @QuestId;";
@@ -626,6 +659,124 @@ public sealed class ContentRepository(IConfiguration configuration) : IContentRe
         return await connection.ExecuteAsync(command) > 0;
     }
 
+    public async Task<int?> ArchiveNpcAsync(
+        int npcId,
+        bool createReplacement,
+        IReadOnlyCollection<ArchivedRecordingFile> archivedRecordings,
+        IReadOnlyCollection<int> deletedRecordingIds,
+        CancellationToken cancellationToken)
+    {
+        await using var connection = new MySqlConnection(DatabaseSettings.GetWebsiteConnectionString(configuration));
+        await connection.OpenAsync(cancellationToken);
+        await using var transaction = await connection.BeginTransactionAsync(cancellationToken);
+
+        try
+        {
+            const string npcSql = """
+                SELECT name AS Name, degenerated_name AS DegeneratedName, archived AS Archived
+                FROM npc
+                WHERE npc_id = @NpcId
+                FOR UPDATE;
+                """;
+
+            var npcCommand = new CommandDefinition(
+                npcSql,
+                new { NpcId = npcId },
+                transaction,
+                cancellationToken: cancellationToken);
+            var npc = await connection.QuerySingleOrDefaultAsync<NpcArchiveRow>(npcCommand);
+            if (npc is null)
+            {
+                await transaction.RollbackAsync(cancellationToken);
+                return null;
+            }
+
+            int? replacementNpcId = null;
+            if (createReplacement)
+            {
+                const string createReplacementSql = """
+                    INSERT INTO npc (name, degenerated_name, voice_actor_id)
+                    VALUES (@Name, @DegeneratedName, NULL);
+                    SELECT LAST_INSERT_ID();
+                    """;
+
+                var createCommand = new CommandDefinition(
+                    createReplacementSql,
+                    new { npc.Name, npc.DegeneratedName },
+                    transaction,
+                    cancellationToken: cancellationToken);
+                replacementNpcId = await connection.ExecuteScalarAsync<int>(createCommand);
+
+                const string moveLinksSql = """
+                    UPDATE npc_quest
+                    SET npc_id = @ReplacementNpcId
+                    WHERE npc_id = @NpcId;
+                    """;
+                var moveLinksCommand = new CommandDefinition(
+                    moveLinksSql,
+                    new { NpcId = npcId, ReplacementNpcId = replacementNpcId },
+                    transaction,
+                    cancellationToken: cancellationToken);
+                await connection.ExecuteAsync(moveLinksCommand);
+            }
+            else
+            {
+                const string deleteLinksSql = "DELETE FROM npc_quest WHERE npc_id = @NpcId;";
+                var deleteLinksCommand = new CommandDefinition(
+                    deleteLinksSql,
+                    new { NpcId = npcId },
+                    transaction,
+                    cancellationToken: cancellationToken);
+                await connection.ExecuteAsync(deleteLinksCommand);
+            }
+
+            const string archiveRecordingSql = """
+                UPDATE recording
+                SET archived = 1, file = @FileName
+                WHERE recording_id = @RecordingId AND npc_id = @NpcId;
+                """;
+            foreach (var recording in archivedRecordings)
+            {
+                var archiveRecordingCommand = new CommandDefinition(
+                    archiveRecordingSql,
+                    new { recording.RecordingId, recording.FileName, NpcId = npcId },
+                    transaction,
+                    cancellationToken: cancellationToken);
+                await connection.ExecuteAsync(archiveRecordingCommand);
+            }
+
+            const string deleteRecordingSql = """
+                DELETE FROM recording
+                WHERE recording_id = @RecordingId AND npc_id = @NpcId;
+                """;
+            foreach (var recordingId in deletedRecordingIds)
+            {
+                var deleteRecordingCommand = new CommandDefinition(
+                    deleteRecordingSql,
+                    new { RecordingId = recordingId, NpcId = npcId },
+                    transaction,
+                    cancellationToken: cancellationToken);
+                await connection.ExecuteAsync(deleteRecordingCommand);
+            }
+
+            const string archiveNpcSql = "UPDATE npc SET archived = 1 WHERE npc_id = @NpcId;";
+            var archiveNpcCommand = new CommandDefinition(
+                archiveNpcSql,
+                new { NpcId = npcId },
+                transaction,
+                cancellationToken: cancellationToken);
+            await connection.ExecuteAsync(archiveNpcCommand);
+
+            await transaction.CommitAsync(cancellationToken);
+            return replacementNpcId;
+        }
+        catch
+        {
+            await transaction.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+
     private sealed class QuestContentRow
     {
         public int QuestId { get; init; }
@@ -646,5 +797,13 @@ public sealed class ContentRepository(IConfiguration configuration) : IContentRe
         public int? SoundEditorId { get; init; }
         public string? SoundEditorName { get; init; }
         public int RecordingCount { get; init; }
+    }
+
+    private sealed class NpcArchiveRow
+    {
+        public int NpcId { get; init; }
+        public string Name { get; init; } = string.Empty;
+        public string DegeneratedName { get; init; } = string.Empty;
+        public bool Archived { get; init; }
     }
 }

--- a/vow-api/src/VoW.Api/Repositories/IContentRepository.cs
+++ b/vow-api/src/VoW.Api/Repositories/IContentRepository.cs
@@ -21,6 +21,8 @@ public interface IContentRepository
 
     Task<bool> NpcExistsAsync(int npcId, CancellationToken cancellationToken);
 
+    Task<NpcArchiveData?> GetNpcArchiveDataAsync(int npcId, CancellationToken cancellationToken);
+
     Task<string?> GetQuestDegeneratedNameAsync(int questId, CancellationToken cancellationToken);
 
     Task<string?> GetNpcDegeneratedNameAsync(int npcId, CancellationToken cancellationToken);
@@ -112,4 +114,11 @@ public interface IContentRepository
         CancellationToken cancellationToken);
 
     Task<bool> UnlinkNpcFromQuestAsync(int questId, int npcId, CancellationToken cancellationToken);
+
+    Task<int?> ArchiveNpcAsync(
+        int npcId,
+        bool createReplacement,
+        IReadOnlyCollection<ArchivedRecordingFile> archivedRecordings,
+        IReadOnlyCollection<int> deletedRecordingIds,
+        CancellationToken cancellationToken);
 }

--- a/vow-api/src/VoW.Api/Services/Content/ContentService.cs
+++ b/vow-api/src/VoW.Api/Services/Content/ContentService.cs
@@ -12,12 +12,14 @@ public sealed partial class ContentService(
     IContentRepository contentRepository,
     IQuestScriptStorage questScriptStorage,
     INpcImageStorage npcImageStorage,
-    INpcRecordingStorage npcRecordingStorage) : IContentService
+    INpcRecordingStorage npcRecordingStorage,
+    ILogger<ContentService> logger) : IContentService
 {
     private const int ContentNameMaxLength = 63;
     private const int RecordingFileNameMaxLength = 63;
     private const short RecordingLineMinValue = 1;
     private const short RecordingLineMaxValue = short.MaxValue;
+    private const int ArchiveRecordingStorageConcurrency = 4;
     private static readonly int[] AllowedPageSizes = [10, 25, 50, 100];
     private static readonly string[] AcceptedRecordingContentTypes = ["audio/ogg", "video/ogg", "application/ogg"];
 
@@ -348,39 +350,97 @@ public sealed partial class ContentService(
         foreach (var recording in archiveData.Recordings)
         {
             var archivedFileName = CreateArchivedRecordingFileName(recording.File, recording.RecordingId, archiveDate);
-            var renamed = await npcRecordingStorage.TryRenameRecordingAsync(
-                recording.File,
-                archivedFileName,
-                cancellationToken);
-            if (renamed)
-            {
-                archivedRecordings.Add(new ArchivedRecordingFile(recording.RecordingId, archivedFileName));
-            }
-            else
-            {
-                deletedRecordingIds.Add(recording.RecordingId);
-            }
+            archivedRecordings.Add(new ArchivedRecordingFile(recording.RecordingId, archivedFileName));
         }
 
+        var archiveCancellationToken = CancellationToken.None;
         var replacementNpcId = await contentRepository.ArchiveNpcAsync(
             npcId,
             request.CreateReplacement,
             archivedRecordings,
             deletedRecordingIds,
-            cancellationToken);
+            archiveCancellationToken);
         if (replacementNpcId is null && request.CreateReplacement)
         {
             return ContentMutationResult.NotFound();
         }
 
+        await ApplyArchivedRecordingRenamesAsync(archiveData.Recordings, archiveDate, archiveCancellationToken);
+
         if (replacementNpcId is not null)
         {
-            await npcImageStorage.CopyImageIfExistsAsync(npcId, replacementNpcId.Value, cancellationToken);
+            await npcImageStorage.CopyImageIfExistsAsync(npcId, replacementNpcId.Value, archiveCancellationToken);
         }
 
         return replacementNpcId is null
             ? ContentMutationResult.Success()
             : ContentMutationResult.Success(replacementNpcId.Value);
+    }
+
+    private async Task ApplyArchivedRecordingRenamesAsync(
+        IReadOnlyCollection<RecordingFile> recordings,
+        string archiveDate,
+        CancellationToken cancellationToken)
+    {
+        using var concurrency = new SemaphoreSlim(ArchiveRecordingStorageConcurrency);
+        var renameTasks = recordings.Select(async recording =>
+        {
+            await concurrency.WaitAsync(cancellationToken);
+            try
+            {
+                var archivedFileName = CreateArchivedRecordingFileName(recording.File, recording.RecordingId, archiveDate);
+                await TryApplyArchivedRecordingRenameAsync(recording, archivedFileName, cancellationToken);
+            }
+            finally
+            {
+                concurrency.Release();
+            }
+        });
+
+        await Task.WhenAll(renameTasks);
+    }
+
+    private async Task TryApplyArchivedRecordingRenameAsync(
+        RecordingFile recording,
+        string archivedFileName,
+        CancellationToken cancellationToken)
+    {
+        const int maxAttempts = 2;
+        for (var attempt = 1; attempt <= maxAttempts; attempt++)
+        {
+            try
+            {
+                if (await npcRecordingStorage.TryRenameRecordingAsync(recording.File, archivedFileName, cancellationToken))
+                {
+                    return;
+                }
+
+                logger.LogError(
+                    "Archived NPC recording {RecordingId} references {ArchivedFileName}, but source blob {SourceFileName} was not found after database commit.",
+                    recording.RecordingId,
+                    archivedFileName,
+                    recording.File);
+                return;
+            }
+            catch (Exception ex) when (attempt < maxAttempts)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Failed to rename archived NPC recording blob {SourceFileName} to {ArchivedFileName}. Retrying.",
+                    recording.File,
+                    archivedFileName);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Archived NPC recording {RecordingId} references {ArchivedFileName}, but blob rename from {SourceFileName} failed after database commit.",
+                    recording.RecordingId,
+                    archivedFileName,
+                    recording.File);
+                throw;
+            }
+        }
     }
 
     public async Task<ContentMutationResult> LinkNpcToQuestAsync(

--- a/vow-api/src/VoW.Api/Services/Content/ContentService.cs
+++ b/vow-api/src/VoW.Api/Services/Content/ContentService.cs
@@ -326,6 +326,63 @@ public sealed partial class ContentService(
             : ContentMutationResult.NotFound();
     }
 
+    public async Task<ContentMutationResult> ArchiveNpcAsync(
+        int npcId,
+        ArchiveNpcRequest request,
+        CancellationToken cancellationToken)
+    {
+        var archiveData = await contentRepository.GetNpcArchiveDataAsync(npcId, cancellationToken);
+        if (archiveData is null)
+        {
+            return ContentMutationResult.NotFound();
+        }
+
+        if (archiveData.Archived)
+        {
+            return ContentMutationResult.Invalid(nameof(npcId), "NPC is already archived.");
+        }
+
+        var archiveDate = DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var archivedRecordings = new List<ArchivedRecordingFile>(archiveData.Recordings.Count);
+        var deletedRecordingIds = new List<int>();
+        foreach (var recording in archiveData.Recordings)
+        {
+            var archivedFileName = CreateArchivedRecordingFileName(recording.File, recording.RecordingId, archiveDate);
+            var renamed = await npcRecordingStorage.TryRenameRecordingAsync(
+                recording.File,
+                archivedFileName,
+                cancellationToken);
+            if (renamed)
+            {
+                archivedRecordings.Add(new ArchivedRecordingFile(recording.RecordingId, archivedFileName));
+            }
+            else
+            {
+                deletedRecordingIds.Add(recording.RecordingId);
+            }
+        }
+
+        var replacementNpcId = await contentRepository.ArchiveNpcAsync(
+            npcId,
+            request.CreateReplacement,
+            archivedRecordings,
+            deletedRecordingIds,
+            cancellationToken);
+        if (replacementNpcId is null && request.CreateReplacement)
+        {
+            return ContentMutationResult.NotFound();
+        }
+
+        if (replacementNpcId is not null)
+        {
+            await npcImageStorage.CopyImageIfExistsAsync(npcId, replacementNpcId.Value, cancellationToken);
+        }
+
+        return replacementNpcId is null
+            ? ContentMutationResult.Success()
+            : ContentMutationResult.Success(replacementNpcId.Value);
+    }
+
     public async Task<ContentMutationResult> LinkNpcToQuestAsync(
         int questId,
         LinkQuestNpcRequest request,
@@ -828,6 +885,19 @@ public sealed partial class ContentService(
             : new StringInfo(stem).SubstringByTextElements(0, maxStemLength);
 
         return FormattableString.Invariant($"{safeStem}{suffix}{extension}");
+    }
+
+    private static string CreateArchivedRecordingFileName(string fileName, int recordingId, string archiveDate)
+    {
+        var stem = Path.GetFileNameWithoutExtension(fileName);
+        const string extension = ".ogg";
+        var prefix = FormattableString.Invariant($"!archived_{archiveDate}_{recordingId}_");
+        var maxStemLength = RecordingFileNameMaxLength - prefix.Length - extension.Length;
+        var safeStem = maxStemLength > 0 && new StringInfo(stem).LengthInTextElements > maxStemLength
+            ? new StringInfo(stem).SubstringByTextElements(0, maxStemLength)
+            : stem;
+
+        return FormattableString.Invariant($"{prefix}{safeStem}{extension}");
     }
 
     private static int ParseRecordingLine(string fileName)

--- a/vow-api/src/VoW.Api/Services/Content/IContentService.cs
+++ b/vow-api/src/VoW.Api/Services/Content/IContentService.cs
@@ -34,6 +34,11 @@ public interface IContentService
         UpdateNpcVoiceActorRequest request,
         CancellationToken cancellationToken);
 
+    Task<ContentMutationResult> ArchiveNpcAsync(
+        int npcId,
+        ArchiveNpcRequest request,
+        CancellationToken cancellationToken);
+
     Task<ContentMutationResult> LinkNpcToQuestAsync(
         int questId,
         LinkQuestNpcRequest request,

--- a/vow-api/src/VoW.Api/Services/Storage/AzureNpcImageStorage.cs
+++ b/vow-api/src/VoW.Api/Services/Storage/AzureNpcImageStorage.cs
@@ -28,6 +28,32 @@ public sealed class AzureNpcImageStorage : INpcImageStorage
         }, cancellationToken: cancellationToken);
     }
 
+    public async Task<bool> CopyImageIfExistsAsync(
+        int sourceNpcId,
+        int destinationNpcId,
+        CancellationToken cancellationToken)
+    {
+        var source = containerClient.GetBlobClient(BlobKey(sourceNpcId));
+        if (!await source.ExistsAsync(cancellationToken))
+        {
+            return false;
+        }
+
+        var destination = containerClient.GetBlobClient(BlobKey(destinationNpcId));
+        var download = await source.DownloadStreamingAsync(cancellationToken: cancellationToken);
+        await using (download.Value.Content)
+        {
+            await destination.UploadAsync(download.Value.Content, overwrite: true, cancellationToken);
+        }
+
+        await destination.SetHttpHeadersAsync(new BlobHttpHeaders
+        {
+            ContentType = ImageContentType,
+            CacheControl = ImageCacheControl,
+        }, cancellationToken: cancellationToken);
+        return true;
+    }
+
     private static string BlobKey(int npcId) =>
         $"{ImageKeyPrefix}{npcId.ToString(CultureInfo.InvariantCulture)}.webp";
 }

--- a/vow-api/src/VoW.Api/Services/Storage/AzureNpcImageStorage.cs
+++ b/vow-api/src/VoW.Api/Services/Storage/AzureNpcImageStorage.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 
@@ -34,13 +35,17 @@ public sealed class AzureNpcImageStorage : INpcImageStorage
         CancellationToken cancellationToken)
     {
         var source = containerClient.GetBlobClient(BlobKey(sourceNpcId));
-        if (!await source.ExistsAsync(cancellationToken))
+        var destination = containerClient.GetBlobClient(BlobKey(destinationNpcId));
+        Response<BlobDownloadStreamingResult> download;
+        try
+        {
+            download = await source.DownloadStreamingAsync(cancellationToken: cancellationToken);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
         {
             return false;
         }
 
-        var destination = containerClient.GetBlobClient(BlobKey(destinationNpcId));
-        var download = await source.DownloadStreamingAsync(cancellationToken: cancellationToken);
         await using (download.Value.Content)
         {
             await destination.UploadAsync(download.Value.Content, overwrite: true, cancellationToken);

--- a/vow-api/src/VoW.Api/Services/Storage/AzureNpcRecordingStorage.cs
+++ b/vow-api/src/VoW.Api/Services/Storage/AzureNpcRecordingStorage.cs
@@ -57,6 +57,11 @@ public sealed class AzureNpcRecordingStorage : INpcRecordingStorage
         string newFileName,
         CancellationToken cancellationToken)
     {
+        if (BlobKey(currentFileName) == BlobKey(newFileName))
+        {
+            return true;
+        }
+
         var source = containerClient.GetBlobClient(BlobKey(currentFileName));
         var destination = containerClient.GetBlobClient(BlobKey(newFileName));
 

--- a/vow-api/src/VoW.Api/Services/Storage/AzureNpcRecordingStorage.cs
+++ b/vow-api/src/VoW.Api/Services/Storage/AzureNpcRecordingStorage.cs
@@ -1,3 +1,4 @@
+using Azure;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
 
@@ -45,16 +46,42 @@ public sealed class AzureNpcRecordingStorage : INpcRecordingStorage
         string newFileName,
         CancellationToken cancellationToken)
     {
+        if (!await TryRenameRecordingAsync(currentFileName, newFileName, cancellationToken))
+        {
+            throw new FileNotFoundException("Recording blob does not exist.", currentFileName);
+        }
+    }
+
+    public async Task<bool> TryRenameRecordingAsync(
+        string currentFileName,
+        string newFileName,
+        CancellationToken cancellationToken)
+    {
         var source = containerClient.GetBlobClient(BlobKey(currentFileName));
         var destination = containerClient.GetBlobClient(BlobKey(newFileName));
 
-        await destination.SyncCopyFromUriAsync(source.Uri, cancellationToken: cancellationToken);
+        Response<BlobDownloadStreamingResult> download;
+        try
+        {
+            download = await source.DownloadStreamingAsync(cancellationToken: cancellationToken);
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404)
+        {
+            return false;
+        }
+
+        await using (download.Value.Content)
+        {
+            await destination.UploadAsync(download.Value.Content, overwrite: true, cancellationToken);
+        }
+
         await destination.SetHttpHeadersAsync(new BlobHttpHeaders
         {
             ContentType = RecordingContentType,
             CacheControl = RecordingCacheControl,
         }, cancellationToken: cancellationToken);
         await source.DeleteIfExistsAsync(cancellationToken: cancellationToken);
+        return true;
     }
 
     public async Task DeleteRecordingAsync(string fileName, CancellationToken cancellationToken)

--- a/vow-api/src/VoW.Api/Services/Storage/INpcImageStorage.cs
+++ b/vow-api/src/VoW.Api/Services/Storage/INpcImageStorage.cs
@@ -18,4 +18,10 @@ public interface INpcImageStorage
     /// <exception cref="ArgumentException">May be thrown when <paramref name="npcId"/> or content is invalid.</exception>
     /// <exception cref="Azure.RequestFailedException">Thrown when the storage provider rejects or fails the upload.</exception>
     Task UploadImageAsync(int npcId, Stream webpContent, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Copies the stored WebP image from one NPC key to another when the source image exists.
+    /// </summary>
+    /// <returns>Whether a source image existed and was copied.</returns>
+    Task<bool> CopyImageIfExistsAsync(int sourceNpcId, int destinationNpcId, CancellationToken cancellationToken);
 }

--- a/vow-api/src/VoW.Api/Services/Storage/INpcRecordingStorage.cs
+++ b/vow-api/src/VoW.Api/Services/Storage/INpcRecordingStorage.cs
@@ -13,5 +13,7 @@ public interface INpcRecordingStorage
 
     Task RenameRecordingAsync(string currentFileName, string newFileName, CancellationToken cancellationToken);
 
+    Task<bool> TryRenameRecordingAsync(string currentFileName, string newFileName, CancellationToken cancellationToken);
+
     Task DeleteRecordingAsync(string fileName, CancellationToken cancellationToken);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive NPC archiving capability to admin content management. Administrators can now archive NPCs with two options: archive and automatically create a replacement NPC (preserving quest references), or archive only without replacement. The system automatically manages recording files and image assets during the archiving process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Team-VoW/VoicesOfWynn-Website/pull/210?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->